### PR TITLE
Refactor E2E check to use default GitHub token

### DIFF
--- a/.github/workflows/manual-e2e-trigger.yml
+++ b/.github/workflows/manual-e2e-trigger.yml
@@ -89,20 +89,11 @@ jobs:
         run: |
           echo "e2e_run_id=$(date -u +%Y%m%dT%H%M%S)-$RANDOM" >> "$GITHUB_OUTPUT"
 
-      - name: Generate App Token for Check Run
-        id: check_run_token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.APP_ID_DISPATCH }}
-          private-key: ${{ secrets.PRIVATE_KEY_DISPATCH }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
       - name: Create Run-Scoped E2E Check
         id: create_check
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.check_run_token.outputs.token }}
+          github-token: ${{ github.token }}
           script: |
             const checkName = `E2E Tests (GCP) — ${{ steps.run_id.outputs.e2e_run_id }}`;
             const sha = '${{ steps.target.outputs.head_sha }}';


### PR DESCRIPTION
Removed the generation of a GitHub App token for check runs and updated the token usage in the E2E check creation step.