### PR TITLE
Add trace propagation and config tests

### DIFF
--- a/grpc/client_stream.go
+++ b/grpc/client_stream.go
@@ -74,22 +74,25 @@ func NewStreamClientInterceptor(logger *slogcp.Logger, opts ...Option) grpc.Stre
 		startTime := time.Now()
 		serviceName, methodName := splitMethodName(method)
 
-		// Prepare outgoing metadata with trace context.
+		// Prepare outgoing metadata, optionally injecting trace headers.
 		originalOutgoingMD, _ := metadata.FromOutgoingContext(ctx)
-		outgoingMDWithTrace := originalOutgoingMD.Copy()
-		// Avoid duplicating injection if headers already exist.
-		if len(outgoingMDWithTrace.Get(traceparentHeader)) == 0 {
-			otel.GetTextMapPropagator().Inject(ctx, metadataCarrier{md: outgoingMDWithTrace})
-		}
-		// Also synthesize X-Cloud-Trace-Context if not present and we have a valid span.
-		if len(outgoingMDWithTrace.Get(xCloudTraceContextHeaderMD)) == 0 {
-			if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
-				if v := formatXCloudTraceContextFromSpanContext(sc); v != "" {
-					outgoingMDWithTrace[xCloudTraceContextHeaderMD] = []string{v}
+		ctxWithOutgoingMD := ctx
+		if cfg.propagateTraceHeaders {
+			outgoingMDWithTrace := originalOutgoingMD.Copy()
+			// Avoid duplicating injection if headers already exist.
+			if len(outgoingMDWithTrace.Get(traceparentHeader)) == 0 {
+				otel.GetTextMapPropagator().Inject(ctx, metadataCarrier{md: outgoingMDWithTrace})
+			}
+			// Also synthesize X-Cloud-Trace-Context if not present and we have a valid span.
+			if len(outgoingMDWithTrace.Get(xCloudTraceContextHeaderMD)) == 0 {
+				if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+					if v := formatXCloudTraceContextFromSpanContext(sc); v != "" {
+						outgoingMDWithTrace[xCloudTraceContextHeaderMD] = []string{v}
+					}
 				}
 			}
+			ctxWithOutgoingMD = metadata.NewOutgoingContext(ctx, outgoingMDWithTrace)
 		}
-		ctxWithOutgoingMD := metadata.NewOutgoingContext(ctx, outgoingMDWithTrace)
 
 		// Filter outgoing metadata *before* calling streamer if logging is enabled.
 		var filteredOutgoingMD metadata.MD

--- a/grpc/propagation_unit_test.go
+++ b/grpc/propagation_unit_test.go
@@ -1,0 +1,129 @@
+//go:build unit
+// +build unit
+
+package grpc
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/pjscruggs/slogcp"
+)
+
+func TestWithTracePropagationUnaryClient(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	lg, err := slogcp.New(slogcp.WithRedirectWriter(io.Discard), slogcp.WithLogTarget(slogcp.LogTargetStdout))
+	if err != nil {
+		t.Fatalf("slogcp.New() returned %v", err)
+	}
+	defer lg.Close()
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    mustTraceID(t, "70f5c2c7b3c0d8eead4837399ac5b327"),
+		SpanID:     mustSpanID(t, "5fa1c6de0d1e3e11"),
+		TraceFlags: trace.FlagsSampled,
+	})
+	baseCtx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	tests := []struct {
+		name       string
+		opt        Option
+		wantHeader bool
+	}{
+		{name: "default", opt: nil, wantHeader: true},
+		{name: "disabled", opt: WithTracePropagation(false), wantHeader: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			interceptor := NewUnaryClientInterceptor(lg, tc.opt)
+			invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+				md, _ := metadata.FromOutgoingContext(ctx)
+				tp := md.Get("traceparent")
+				xc := md.Get("x-cloud-trace-context")
+				if tc.wantHeader {
+					if len(tp) == 0 || len(xc) == 0 {
+						t.Errorf("headers missing: traceparent=%q x-cloud=%q", tp, xc)
+					}
+				} else {
+					if len(tp) > 0 || len(xc) > 0 {
+						t.Errorf("headers injected when disabled: traceparent=%q x-cloud=%q", tp, xc)
+					}
+				}
+				return nil
+			}
+			if err := interceptor(baseCtx, "/svc/m", nil, nil, nil, invoker); err != nil {
+				t.Fatalf("interceptor returned %v", err)
+			}
+		})
+	}
+}
+
+func TestContextOnlyServerStream(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	var buf bytes.Buffer
+	lg, err := slogcp.New(slogcp.WithRedirectWriter(&buf), slogcp.WithLogTarget(slogcp.LogTargetStdout))
+	if err != nil {
+		t.Fatalf("slogcp.New() returned %v", err)
+	}
+	defer lg.Close()
+
+	interceptor := StreamServerInterceptor(lg, WithShouldLog(func(context.Context, string) bool { return false }), WithMetadataLogging(true), WithPayloadLogging(true))
+
+	traceHex := "70f5c2c7b3c0d8eead4837399ac5b327"
+	spanHex := "5fa1c6de0d1e3e11"
+	md := metadata.New(map[string]string{"traceparent": "00-" + traceHex + "-" + spanHex + "-01"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	ss := &testServerStream{ctx: ctx}
+
+	handler := func(srv any, stream grpc.ServerStream) error {
+		sc := trace.SpanContextFromContext(stream.Context())
+		if sc.TraceID().String() != traceHex || sc.SpanID().String() != spanHex {
+			t.Errorf("context missing trace: %v", sc)
+		}
+		return nil
+	}
+	info := &grpc.StreamServerInfo{FullMethod: "/svc/Method"}
+
+	if err := interceptor(nil, ss, info, handler); err != nil {
+		t.Fatalf("interceptor returned %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no logs, got %s", buf.String())
+	}
+}
+
+type testServerStream struct{ ctx context.Context }
+
+func (tss *testServerStream) SetHeader(metadata.MD) error  { return nil }
+func (tss *testServerStream) SendHeader(metadata.MD) error { return nil }
+func (tss *testServerStream) SetTrailer(metadata.MD)       {}
+func (tss *testServerStream) Context() context.Context     { return tss.ctx }
+func (tss *testServerStream) SendMsg(interface{}) error    { return nil }
+func (tss *testServerStream) RecvMsg(interface{}) error    { return nil }
+
+func mustTraceID(t *testing.T, hex string) trace.TraceID {
+	t.Helper()
+	id, err := trace.TraceIDFromHex(hex)
+	if err != nil {
+		t.Fatalf("TraceIDFromHex(%q) returned %v", hex, err)
+	}
+	return id
+}
+
+func mustSpanID(t *testing.T, hex string) trace.SpanID {
+	t.Helper()
+	id, err := trace.SpanIDFromHex(hex)
+	if err != nil {
+		t.Fatalf("SpanIDFromHex(%q) returned %v", hex, err)
+	}
+	return id
+}

--- a/grpc/trace_parsers_unit_test.go
+++ b/grpc/trace_parsers_unit_test.go
@@ -1,0 +1,72 @@
+//go:build unit
+// +build unit
+
+package grpc
+
+import (
+	"strconv"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestParseTraceparent(t *testing.T) {
+	traceHex := "70f5c2c7b3c0d8eead4837399ac5b327"
+	spanHex := "5fa1c6de0d1e3e11"
+	md := metadata.New(map[string]string{
+		"traceparent": "00-" + traceHex + "-" + spanHex + "-01",
+	})
+	sc, ok := parseTraceparent(md)
+	if !ok {
+		t.Fatalf("parseTraceparent() returned ok=false")
+	}
+	if sc.TraceID().String() != traceHex || sc.SpanID().String() != spanHex || !sc.IsSampled() {
+		t.Errorf("parseTraceparent() = %v", sc)
+	}
+
+	mdBad := metadata.New(map[string]string{"traceparent": "bad"})
+	if _, ok := parseTraceparent(mdBad); ok {
+		t.Errorf("parseTraceparent() with bad header returned ok=true")
+	}
+}
+
+func TestParseXCloudTraceContext(t *testing.T) {
+	traceHex := "70f5c2c7b3c0d8eead4837399ac5b327"
+	spanHex := "5fa1c6de0d1e3e11"
+	spanUint, err := strconv.ParseUint(spanHex, 16, 64)
+	if err != nil {
+		t.Fatalf("ParseUint(%q) returned %v", spanHex, err)
+	}
+	spanDec := strconv.FormatUint(spanUint, 10)
+	md := metadata.New(map[string]string{
+		"x-cloud-trace-context": traceHex + "/" + spanDec + ";o=1",
+	})
+	sc, ok := parseXCloudTraceContext(md)
+	if !ok {
+		t.Fatalf("parseXCloudTraceContext() returned ok=false")
+	}
+	if sc.TraceID().String() != traceHex || sc.SpanID() != mustSpanID(t, spanHex) || !sc.IsSampled() {
+		t.Errorf("parseXCloudTraceContext() = %v", sc)
+	}
+
+	mdBad := metadata.New(map[string]string{"x-cloud-trace-context": "bad"})
+	if _, ok := parseXCloudTraceContext(mdBad); ok {
+		t.Errorf("parseXCloudTraceContext() with bad header returned ok=true")
+	}
+}
+
+func TestFormatXCloudTraceContextFromSpanContext(t *testing.T) {
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    mustTraceID(t, "70f5c2c7b3c0d8eead4837399ac5b327"),
+		SpanID:     mustSpanID(t, "5fa1c6de0d1e3e11"),
+		TraceFlags: trace.FlagsSampled,
+	})
+	want := "70f5c2c7b3c0d8eead4837399ac5b327/6891007561858694673;o=1"
+	if got := formatXCloudTraceContextFromSpanContext(sc); got != want {
+		t.Errorf("formatXCloudTraceContextFromSpanContext() = %q, want %q", got, want)
+	}
+	if got := formatXCloudTraceContextFromSpanContext(trace.SpanContext{}); got != "" {
+		t.Errorf("formatXCloudTraceContextFromSpanContext(invalid) = %q, want empty", got)
+	}
+}

--- a/http/trace_transport_unit_test.go
+++ b/http/trace_transport_unit_test.go
@@ -1,0 +1,109 @@
+//go:build unit
+// +build unit
+
+package http
+
+import (
+	"context"
+	"io"
+	stdhttp "net/http"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func mustTraceID(hexStr string) trace.TraceID {
+	id, err := trace.TraceIDFromHex(hexStr)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
+func mustSpanID(hexStr string) trace.SpanID {
+	id, err := trace.SpanIDFromHex(hexStr)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
+func TestInjectTraceContextFromHeader(t *testing.T) {
+	traceHex := "70f5c2c7b3c0d8eead4837399ac5b327"
+
+	ctx := injectTraceContextFromHeader(context.Background(), traceHex)
+	sc := trace.SpanContextFromContext(ctx)
+	if sc.TraceID().String() != traceHex || !sc.SpanID().IsValid() || sc.IsSampled() {
+		t.Errorf("injectTraceContextFromHeader(no span) = %v", sc)
+	}
+
+	header := traceHex + "/6891007561858694673"
+	ctx2 := injectTraceContextFromHeader(context.Background(), header)
+	sc2 := trace.SpanContextFromContext(ctx2)
+	if sc2.TraceID().String() != traceHex || sc2.SpanID().String() != "5fa1c6de0d1e3e11" || sc2.IsSampled() {
+		t.Errorf("injectTraceContextFromHeader(with span) = %v", sc2)
+	}
+}
+
+type captureRoundTripper struct{ hdr stdhttp.Header }
+
+func (c *captureRoundTripper) RoundTrip(req *stdhttp.Request) (*stdhttp.Response, error) {
+	c.hdr = req.Header.Clone()
+	return &stdhttp.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader("")), Request: req}, nil
+}
+
+func newRequestWithSpan() *stdhttp.Request {
+	req, _ := stdhttp.NewRequest("GET", "http://example.com", nil)
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    mustTraceID("70f5c2c7b3c0d8eead4837399ac5b327"),
+		SpanID:     mustSpanID("5fa1c6de0d1e3e11"),
+		TraceFlags: trace.FlagsSampled,
+	})
+	req = req.WithContext(trace.ContextWithSpanContext(context.Background(), sc))
+	return req
+}
+
+func TestTracePropagationTransport(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	cap := &captureRoundTripper{}
+	tp := TracePropagationTransport{Base: cap}
+	if _, err := tp.RoundTrip(newRequestWithSpan()); err != nil {
+		t.Fatalf("RoundTrip returned %v", err)
+	}
+	if cap.hdr.Get("traceparent") == "" || cap.hdr.Get(XCloudTraceContextHeader) == "" {
+		t.Errorf("headers not injected: %v", cap.hdr)
+	}
+
+	cap2 := &captureRoundTripper{}
+	tp2 := TracePropagationTransport{Base: cap2, Skip: func(*stdhttp.Request) bool { return true }}
+	if _, err := tp2.RoundTrip(newRequestWithSpan()); err != nil {
+		t.Fatalf("RoundTrip returned %v", err)
+	}
+	if cap2.hdr.Get("traceparent") != "" || cap2.hdr.Get(XCloudTraceContextHeader) != "" {
+		t.Errorf("headers injected despite skip: %v", cap2.hdr)
+	}
+}
+
+func TestNewTraceRoundTripper(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	cap := &captureRoundTripper{}
+	rt := NewTraceRoundTripper(cap)
+	if _, err := rt.RoundTrip(newRequestWithSpan()); err != nil {
+		t.Fatalf("RoundTrip returned %v", err)
+	}
+	if cap.hdr.Get("traceparent") == "" || cap.hdr.Get(XCloudTraceContextHeader) == "" {
+		t.Errorf("headers not injected: %v", cap.hdr)
+	}
+
+	cap2 := &captureRoundTripper{}
+	rt2 := NewTraceRoundTripper(cap2, WithSkip(func(*stdhttp.Request) bool { return true }))
+	if _, err := rt2.RoundTrip(newRequestWithSpan()); err != nil {
+		t.Fatalf("RoundTrip returned %v", err)
+	}
+	if cap2.hdr.Get("traceparent") != "" || cap2.hdr.Get(XCloudTraceContextHeader) != "" {
+		t.Errorf("headers injected despite skip: %v", cap2.hdr)
+	}
+}

--- a/internal/gcp/config_unit_test.go
+++ b/internal/gcp/config_unit_test.go
@@ -1,0 +1,36 @@
+//go:build unit
+// +build unit
+
+package gcp
+
+import "testing"
+
+func TestLoadConfigTraceProjectID(t *testing.T) {
+	t.Setenv("SLOGCP_LOG_TARGET", "stdout")
+	t.Setenv("SLOGCP_PROJECT_ID", "base")
+	t.Setenv("SLOGCP_TRACE_PROJECT_ID", "trace")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() returned %v, want nil", err)
+	}
+	if cfg.ProjectID != "base" {
+		t.Errorf("ProjectID = %q, want %q", cfg.ProjectID, "base")
+	}
+	if cfg.TraceProjectID != "trace" {
+		t.Errorf("TraceProjectID = %q, want %q", cfg.TraceProjectID, "trace")
+	}
+}
+
+func TestLoadConfigTraceProjectIDDefault(t *testing.T) {
+	t.Setenv("SLOGCP_LOG_TARGET", "stdout")
+	t.Setenv("SLOGCP_PROJECT_ID", "base")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() returned %v, want nil", err)
+	}
+	if cfg.TraceProjectID != "base" {
+		t.Errorf("TraceProjectID = %q, want %q", cfg.TraceProjectID, "base")
+	}
+}

--- a/internal/gcp/operation_unit_test.go
+++ b/internal/gcp/operation_unit_test.go
@@ -1,0 +1,78 @@
+//go:build unit
+// +build unit
+
+package gcp
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	logpb "google.golang.org/genproto/googleapis/logging/v2"
+)
+
+func TestExtractOperationFromRecord(t *testing.T) {
+	r := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+	r.AddAttrs(slog.Group(operationGroupKey,
+		slog.String("id", "123"),
+		slog.String("producer", "prod"),
+		slog.Bool("first", true),
+		slog.Bool("last", false),
+	))
+	op := ExtractOperationFromRecord(r)
+	if op == nil {
+		t.Fatalf("ExtractOperationFromRecord() returned nil, want non-nil")
+	}
+	if op.Id != "123" || op.Producer != "prod" || !op.First || op.Last {
+		t.Errorf("ExtractOperationFromRecord() = %#v", op)
+	}
+
+	r2 := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+	if got := ExtractOperationFromRecord(r2); got != nil {
+		t.Errorf("ExtractOperationFromRecord() = %#v, want nil", got)
+	}
+}
+
+func TestExtractOperationFromPayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]any
+		want    *logpb.LogEntryOperation
+	}{
+		{
+			name: "valid",
+			payload: map[string]any{
+				operationGroupKey: map[string]any{
+					"id":       "123",
+					"producer": "prod",
+					"first":    true,
+					"last":     "true",
+				},
+			},
+			want: &logpb.LogEntryOperation{Id: "123", Producer: "prod", First: true, Last: true},
+		},
+		{
+			name:    "missing",
+			payload: map[string]any{},
+			want:    nil,
+		},
+		{
+			name:    "wrong type",
+			payload: map[string]any{operationGroupKey: "oops"},
+			want:    nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractOperationFromPayload(tc.payload)
+			if (got == nil) != (tc.want == nil) {
+				t.Fatalf("ExtractOperationFromPayload() = %#v, want %#v", got, tc.want)
+			}
+			if got != nil {
+				if got.Id != tc.want.Id || got.Producer != tc.want.Producer || got.First != tc.want.First || got.Last != tc.want.Last {
+					t.Errorf("ExtractOperationFromPayload() = %#v, want %#v", got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/gcp/trace_utils_unit_test.go
+++ b/internal/gcp/trace_utils_unit_test.go
@@ -1,0 +1,53 @@
+//go:build unit
+// +build unit
+
+package gcp
+
+import (
+	"testing"
+)
+
+func TestFormatTraceResource(t *testing.T) {
+	got := FormatTraceResource("proj", "abc123")
+	want := "projects/proj/traces/abc123"
+	if got != want {
+		t.Errorf("FormatTraceResource() = %q, want %q", got, want)
+	}
+}
+
+func TestSpanIDHexToDecimal(t *testing.T) {
+	tests := []struct {
+		hex     string
+		wantDec string
+		ok      bool
+	}{
+		{hex: "0000000000000001", wantDec: "1", ok: true},
+		{hex: "5fa1c6de0d1e3e11", wantDec: "6891007561858694673", ok: true},
+		{hex: "zz", wantDec: "", ok: false},
+	}
+	for _, tc := range tests {
+		got, ok := SpanIDHexToDecimal(tc.hex)
+		if ok != tc.ok || got != tc.wantDec {
+			t.Errorf("SpanIDHexToDecimal(%q) = (%q, %v), want (%q, %v)", tc.hex, got, ok, tc.wantDec, tc.ok)
+		}
+	}
+}
+
+func TestBuildXCloudTraceContext(t *testing.T) {
+	tests := []struct {
+		traceID string
+		spanHex string
+		sampled bool
+		want    string
+	}{
+		{"70f5c2c7b3c0d8eead4837399ac5b327", "5fa1c6de0d1e3e11", true, "70f5c2c7b3c0d8eead4837399ac5b327/6891007561858694673;o=1"},
+		{"70f5c2c7b3c0d8eead4837399ac5b327", "", false, "70f5c2c7b3c0d8eead4837399ac5b327;o=0"},
+		{"70f5c2c7b3c0d8eead4837399ac5b327", "zz", true, "70f5c2c7b3c0d8eead4837399ac5b327;o=1"},
+	}
+	for _, tc := range tests {
+		got := BuildXCloudTraceContext(tc.traceID, tc.spanHex, tc.sampled)
+		if got != tc.want {
+			t.Errorf("BuildXCloudTraceContext(%q,%q,%v) = %q, want %q", tc.traceID, tc.spanHex, tc.sampled, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- gate gRPC client trace header injection behind WithTracePropagation
- add unit tests for trace propagation, HTTP transport injection, trace utilities, operation extraction, and config defaults

## Testing
- `go test -tags=unit ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c10fb265708325a7d20ef12f09cded