### PR TITLE
ci: classify security floor example metadata

### DIFF
--- a/.github/workflows/validation_pipeline.yml
+++ b/.github/workflows/validation_pipeline.yml
@@ -46,8 +46,13 @@ jobs:
               const onlyExampleModuleMetadata = paths.length > 0 &&
                 paths.every(p => /^\.examples\/.+\/go\.(mod|sum)$/.test(p));
               const touchesRootGoModuleMetadata = paths.some(p => /^go\.(mod|sum)$/.test(p));
+              const allowedSecurityFloorMetadata = p =>
+                p === 'go.mod' ||
+                p === 'go.sum' ||
+                p === 'version.go' ||
+                /^\.examples\/.+\/go\.(mod|sum)$/.test(p);
               const securityFloorFileScope = paths.length > 0 &&
-                paths.every(p => p === 'go.mod' || p === 'go.sum' || p === 'version.go');
+                paths.every(allowedSecurityFloorMetadata);
               const pr = context.payload.pull_request;
               const sameRepo = pr.head.repo.full_name === context.payload.repository.full_name;
               const actor = pr.user.login;
@@ -484,8 +489,13 @@ jobs:
             const onlyExampleModuleMetadata = paths.length > 0 &&
               paths.every(p => /^\.examples\/.+\/go\.(mod|sum)$/.test(p));
             const touchesRootGoModuleMetadata = paths.some(p => /^go\.(mod|sum)$/.test(p));
+            const allowedSecurityFloorMetadata = p =>
+              p === 'go.mod' ||
+              p === 'go.sum' ||
+              p === 'version.go' ||
+              /^\.examples\/.+\/go\.(mod|sum)$/.test(p);
             const securityFloorFileScope = paths.length > 0 &&
-              paths.every(p => p === 'go.mod' || p === 'go.sum' || p === 'version.go');
+              paths.every(allowedSecurityFloorMetadata);
             const pr = context.payload.pull_request;
             const sameRepo = pr.head.repo.full_name === context.payload.repository.full_name;
             const actor = pr.user.login;


### PR DESCRIPTION
## Summary

Classify Renovate security-floor PRs as security floor even when Renovate also updates checked-in example module metadata.

## Why

The first Renovate security PRs touched root `go.mod`/`go.sum` plus `.examples/**/go.mod` and `.examples/**/go.sum`. The previous classifier treated that as a normal PR, which forced manual E2E instead of the intended security-floor automation.

## Validation

- `actionlint .github/workflows/validation_pipeline.yml`
- `git diff --check`