### PR TITLE
ci: decouple example Go sync from security floor validation

### DIFF
--- a/.github/workflows/validation_pipeline.yml
+++ b/.github/workflows/validation_pipeline.yml
@@ -222,6 +222,7 @@ jobs:
           fi
 
       - name: 🧹 Sync example Go directives
+        if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'renovate:go-version')
         run: python3 .github/scripts/sync_example_go_versions.py
 
       - name: 📅🕰️ Get current year in US Central Time
@@ -310,6 +311,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ✅ Verify example Go directives
+        if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'renovate:go-version')
         run: python3 .github/scripts/sync_example_go_versions.py --check
 
       - name: ♻️ Restore Go toolchain (pre-tests)


### PR DESCRIPTION
Summary:
- Gate example Go directive sync/check steps to dedicated renovate go-version PRs.
- Prevent security-floor dependency PRs from failing due unrelated latest-Go example maintenance drift.

Verification:
- actionlint .github\workflows\validation_pipeline.yml
- YAML parse with PyYAML using UTF-8
- python -m unittest scripts.test_mock_github_ci scripts.test_mock_renovate
- git diff --check