### PR TITLE
fix(renovate): hide routine root floor updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -74,20 +74,19 @@
       "prPriority": 10
     },
     {
-      "description": "Normal root Go module dependency updates require maintainer approval from the Dependency Dashboard",
+      "description": "Do not propose routine root go.mod dependency floor updates",
       "matchManagers": ["gomod"],
       "matchFileNames": ["go.mod"],
-      "dependencyDashboardApproval": true,
-      "automerge": false,
-      "groupName": "root dependency floor candidates",
-      "labels": ["dependency-scope:root"],
-      "prPriority": 0
+      "matchDatasources": ["go"],
+      "matchDepTypes": ["require"],
+      "enabled": false
     },
     {
       "description": "Security floor updates must not wait for normal root Dependency Dashboard approval",
       "matchManagers": ["gomod"],
       "matchFileNames": ["go.mod"],
       "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "enabled": true,
       "dependencyDashboardApproval": false,
       "automerge": true,
       "automergeType": "pr",


### PR DESCRIPTION
## Summary
- Disable routine root go.mod direct dependency floor update proposals.
- Keep vulnerability-driven root security floor updates enabled and automatic.

## Validation
- `git diff --check`
- `Get-Content renovate.json | python -m json.tool | Out-Null`
- `$env:npm_config_engine_strict='false'; npx --yes --package renovate@43.212.2 -- renovate-config-validator`

## Merge Notes
This is a normal config PR. Main protection still requires `Local Validation Policy` and `E2E Tests (GCP)` before squash merge. After local validation passes, run the manual E2E workflow for this PR number.