### PR TITLE
fix(renovate): automerge example dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -127,7 +127,10 @@
       "matchFileNames": [".examples/**"],
       "groupName": "examples module dependencies",
       "labels": ["renovate:examples", "dependency-scope:examples"],
-      "schedule": ["* 4 * * *"],
+      "schedule": ["* 3-6 * * *"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
       "prPriority": 5
     },
     {


### PR DESCRIPTION
## Summary
- enable Renovate PR automerge for checked-in example module dependency updates
- widen the examples dependency update window so scheduled runs are less likely to miss it
- require squash merges for these Renovate automerges

## Validation
- git diff --check
- python -m json.tool
- renovate-config-validator