### PR TITLE
chore: apply updated maintenance tool output

### DIFF
--- a/.e2e/services/e2e-harness/main_test.go
+++ b/.e2e/services/e2e-harness/main_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 )
 
+// TestHarnessTimeoutDefaultUsesEnvironmentSeconds verifies the harness timeout honors the environment override.
 func TestHarnessTimeoutDefaultUsesEnvironmentSeconds(t *testing.T) {
 	t.Setenv("E2E_TIMEOUT_SECONDS", "5400")
 
@@ -32,6 +33,7 @@ func TestHarnessTimeoutDefaultUsesEnvironmentSeconds(t *testing.T) {
 	}
 }
 
+// TestHarnessTimeoutDefaultRejectsInvalidEnvironmentSeconds verifies invalid environment overrides are rejected.
 func TestHarnessTimeoutDefaultRejectsInvalidEnvironmentSeconds(t *testing.T) {
 	t.Setenv("E2E_TIMEOUT_SECONDS", "25m")
 

--- a/errorreporting.go
+++ b/errorreporting.go
@@ -91,8 +91,8 @@ func buildErrorReportingConfig(opts []ErrorReportingOption) errorReportingConfig
 		return cfg
 	}
 
-	cfg.service = firstNonEmptyString(cfg.service, info.ServiceContext["service"])
-	cfg.version = firstNonEmptyString(cfg.version, info.ServiceContext["version"])
+	cfg.service = firstNonEmptyString(cfg.service, info.ServiceContext[serviceContextServiceKey])
+	cfg.version = firstNonEmptyString(cfg.version, info.ServiceContext[serviceContextVersionKey])
 	return cfg
 }
 
@@ -125,9 +125,9 @@ func buildServiceContextAttrs(cfg errorReportingConfig) []slog.Attr {
 	if cfg.service == "" {
 		return nil
 	}
-	sc := map[string]any{"service": cfg.service}
+	sc := map[string]any{serviceContextServiceKey: cfg.service}
 	if cfg.version != "" {
-		sc["version"] = cfg.version
+		sc[serviceContextVersionKey] = cfg.version
 	}
 	return []slog.Attr{slog.Any("serviceContext", sc)}
 }

--- a/handler.go
+++ b/handler.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -473,8 +474,8 @@ func composeFanout(primary slog.Handler, additional []slog.Handler, leveler slog
 
 // applyMiddlewares wraps handler with supplied middlewares from last to first.
 func applyMiddlewares(handler slog.Handler, middlewares []Middleware) slog.Handler {
-	for i := len(middlewares) - 1; i >= 0; i-- {
-		handler = middlewares[i](handler)
+	for _, middleware := range slices.Backward(middlewares) {
+		handler = middleware(handler)
 	}
 	return handler
 }
@@ -1450,17 +1451,24 @@ func resolveLevelFromEnv(current slog.Level, logger *slog.Logger) slog.Level {
 	return parseLevelEnv(os.Getenv(envGenericLogLevel), current, logger)
 }
 
+const (
+	envLevelAliasDefault   = "default"
+	envLevelAliasCritical  = "critical"
+	envLevelAliasAlert     = "alert"
+	envLevelAliasEmergency = "emergency"
+)
+
 var envLevelAliases = map[string]slog.Level{
-	"debug":     slog.LevelDebug,
-	"info":      slog.LevelInfo,
-	"warn":      slog.LevelWarn,
-	"warning":   slog.LevelWarn,
-	"error":     slog.LevelError,
-	"default":   slog.Level(LevelDefault),
-	"notice":    slog.Level(LevelNotice),
-	"critical":  slog.Level(LevelCritical),
-	"alert":     slog.Level(LevelAlert),
-	"emergency": slog.Level(LevelEmergency),
+	"debug":                slog.LevelDebug,
+	"info":                 slog.LevelInfo,
+	"warn":                 slog.LevelWarn,
+	"warning":              slog.LevelWarn,
+	"error":                slog.LevelError,
+	envLevelAliasDefault:   slog.Level(LevelDefault),
+	"notice":               slog.Level(LevelNotice),
+	envLevelAliasCritical:  slog.Level(LevelCritical),
+	envLevelAliasAlert:     slog.Level(LevelAlert),
+	envLevelAliasEmergency: slog.Level(LevelEmergency),
 }
 
 // parseLevelEnv parses slog levels from environment variables, retaining the

--- a/handler_test.go
+++ b/handler_test.go
@@ -2223,16 +2223,16 @@ func (l *diagRecorder) Printf(format string, args ...any) {
 type concurrencyTrackingWriter struct {
 	buf                 bytes.Buffer
 	mu                  sync.Mutex
-	activeWriters       int32
-	concurrentWriteSeen int32
+	activeWriters       atomic.Int32
+	concurrentWriteSeen atomic.Int32
 }
 
 // Write records the supplied bytes while detecting overlapping writes.
 func (w *concurrencyTrackingWriter) Write(p []byte) (int, error) {
-	if atomic.AddInt32(&w.activeWriters, 1) > 1 {
-		atomic.StoreInt32(&w.concurrentWriteSeen, 1)
+	if w.activeWriters.Add(1) > 1 {
+		w.concurrentWriteSeen.Store(1)
 	}
-	defer atomic.AddInt32(&w.activeWriters, -1)
+	defer w.activeWriters.Add(-1)
 
 	// Yield briefly to increase the surface for overlapping writes when locks are missing.
 	time.Sleep(500 * time.Microsecond)
@@ -2251,7 +2251,7 @@ func (w *concurrencyTrackingWriter) String() string {
 
 // ConcurrencyDetected reports whether overlapping writes were observed.
 func (w *concurrencyTrackingWriter) ConcurrencyDetected() bool {
-	return atomic.LoadInt32(&w.concurrentWriteSeen) != 0
+	return w.concurrentWriteSeen.Load() != 0
 }
 
 // decodeLogEntries parses newline-delimited JSON records for assertions.

--- a/json_payload.go
+++ b/json_payload.go
@@ -29,6 +29,8 @@ const (
 	stackTraceKey  = "stack_trace"
 	httpRequestKey = "httpRequest"
 	labelsGroupKey = "logging.googleapis.com/labels"
+	boolLabelTrue  = "true"
+	boolLabelFalse = "false"
 )
 
 // formattedError holds the processed error details for structured logging.
@@ -230,9 +232,9 @@ func labelValueToStringResolved(rv slog.Value) (string, bool) {
 // boolLabel formats boolean values for labels.
 func boolLabel(value bool) (string, bool) {
 	if value {
-		return "true", true
+		return boolLabelTrue, true
 	}
-	return "false", true
+	return boolLabelFalse, true
 }
 
 // labelFromAny converts arbitrary values into label strings when possible.

--- a/levels.go
+++ b/levels.go
@@ -17,6 +17,7 @@ package slogcp
 import (
 	"fmt"
 	"log/slog"
+	"slices"
 )
 
 // Level represents the severity of a log event, extending slog.Level
@@ -80,6 +81,8 @@ const (
 	LevelDefault Level = 30
 )
 
+const severityNoticeName = "NOTICE"
+
 type severityDescriptor struct {
 	threshold Level
 	levelName string
@@ -90,7 +93,7 @@ type severityDescriptor struct {
 var severityDescriptors = []severityDescriptor{
 	{threshold: LevelDebug, levelName: "DEBUG", fullName: "DEBUG", alias: "D"},
 	{threshold: LevelInfo, levelName: "INFO", fullName: "INFO", alias: "I"},
-	{threshold: LevelNotice, levelName: "NOTICE", fullName: "NOTICE", alias: "N"},
+	{threshold: LevelNotice, levelName: severityNoticeName, fullName: severityNoticeName, alias: "N"},
 	{threshold: LevelWarn, levelName: "WARN", fullName: "WARNING", alias: "W"},
 	{threshold: LevelError, levelName: "ERROR", fullName: "ERROR", alias: "E"},
 	{threshold: LevelCritical, levelName: "CRITICAL", fullName: "CRITICAL", alias: "C"},
@@ -104,9 +107,9 @@ var severityDescriptors = []severityDescriptor{
 // match.
 func descriptorForLevel(level Level) severityDescriptor {
 	desc := severityDescriptors[0]
-	for i := len(severityDescriptors) - 1; i >= 0; i-- {
-		if level >= severityDescriptors[i].threshold {
-			return severityDescriptors[i]
+	for _, severityDescriptor := range slices.Backward(severityDescriptors) {
+		if level >= severityDescriptor.threshold {
+			return severityDescriptor
 		}
 	}
 	return desc

--- a/runtime_info.go
+++ b/runtime_info.go
@@ -57,6 +57,11 @@ const (
 	RuntimeEnvComputeEngine
 )
 
+const (
+	serviceContextServiceKey = "service"
+	serviceContextVersionKey = "version"
+)
+
 var (
 	runtimeInfoGet           atomic.Value // func() RuntimeInfo
 	runtimeInfoCacheDisabled atomic.Bool
@@ -254,10 +259,10 @@ func detectCloudFunction(info *RuntimeInfo, md *metadataLookup) bool {
 	)
 
 	info.ServiceContext = map[string]string{
-		"service": service,
+		serviceContextServiceKey: service,
 	}
 	if revision != "" {
-		info.ServiceContext["version"] = revision
+		info.ServiceContext[serviceContextVersionKey] = revision
 	}
 
 	labels := map[string]string{
@@ -294,8 +299,8 @@ func detectCloudRunService(info *RuntimeInfo, md *metadataLookup) bool {
 	)
 
 	info.ServiceContext = map[string]string{
-		"service": service,
-		"version": revision,
+		serviceContextServiceKey: service,
+		serviceContextVersionKey: revision,
 	}
 
 	labels := map[string]string{
@@ -336,8 +341,8 @@ func detectCloudRunJob(info *RuntimeInfo, md *metadataLookup) bool {
 	)
 
 	info.ServiceContext = map[string]string{
-		"service": job,
-		"version": execution,
+		serviceContextServiceKey: job,
+		serviceContextVersionKey: execution,
 	}
 
 	labels := map[string]string{
@@ -375,8 +380,8 @@ func detectAppEngine(info *RuntimeInfo, md *metadataLookup) bool {
 	}
 
 	info.ServiceContext = map[string]string{
-		"service": service,
-		"version": version,
+		serviceContextServiceKey: service,
+		serviceContextVersionKey: version,
 	}
 	labels := map[string]string{
 		"appengine.service":  service,
@@ -673,8 +678,7 @@ func metadataLookupDisablesAvailability(err error) bool {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
-	var nde metadata.NotDefinedError
-	if errors.As(err, &nde) {
+	if _, ok := errors.AsType[metadata.NotDefinedError](err); ok {
 		return false
 	}
 	var netErr net.Error

--- a/stack.go
+++ b/stack.go
@@ -26,6 +26,7 @@ import (
 // Constants defining the maximum stack frames to capture for fallback traces.
 const (
 	maxStackFrames = 64
+	runtimeGoexit  = "runtime.goexit"
 )
 
 var stackPCPool = sync.Pool{
@@ -48,9 +49,10 @@ var (
 	goroutineHeaderFunc = defaultGoroutineHeader
 )
 
-// stackTracer defines an interface errors can implement to provide their own stack trace
+// stackTracer defines an error interface that can provide its own stack trace
 // in the form of program counters.
 type stackTracer interface {
+	error
 	StackTrace() []uintptr
 }
 
@@ -76,8 +78,7 @@ func stackPCsFromError(err error) []uintptr {
 		return nil
 	}
 
-	var st stackTracer
-	if errors.As(err, &st) {
+	if st, ok := errors.AsType[stackTracer](err); ok {
 		if pcs := st.StackTrace(); len(pcs) > 0 {
 			return pcs
 		}
@@ -220,7 +221,7 @@ func frameShouldStop(frame runtime.Frame) bool {
 // frameSkipState returns whether to skip the frame and whether iteration should end.
 func frameSkipState(frame runtime.Frame, more bool) (skip bool, stop bool) {
 	switch frame.Function {
-	case "runtime.goexit":
+	case runtimeGoexit:
 		return true, !more
 	case "":
 		return true, !more
@@ -285,7 +286,7 @@ func trimStackPCs(pcs []uintptr, skipFn func(string) bool) []uintptr {
 var (
 	internalStackFrameNames = map[string]struct{}{
 		"runtime.Callers": {},
-		"runtime.goexit":  {},
+		runtimeGoexit:     {},
 	}
 	internalStackFramePrefixes = []string{
 		"runtime.",


### PR DESCRIPTION
Applies the source changes now required by the updated maintenance toolchain from the CI dependency update: modernize/goimports/golangci-lint output plus missing test docs. This keeps follow-up PR validation from failing with a dirty working tree. No version.go change and no release intent. Validation: python scripts/run_tests.py passed with 559 tests, 100.00% coverage, no missing docs, no vulnerabilities, and golangci-lint reporting 0 issues. The runner generated example dependency metadata during validation; those generated changes were intentionally left out because Renovate owns example dependency updates.