### PR TITLE
fix(renovate): automerge e2e docker updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -134,6 +134,17 @@
       "prPriority": 5
     },
     {
+      "description": "Automerge Docker dependencies used by e2e tests after validation",
+      "matchManagers": ["dockerfile"],
+      "matchFileNames": [".e2e/**"],
+      "groupName": "e2e docker dependencies",
+      "labels": ["renovate:e2e", "dependency-scope:e2e"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "prPriority": 5
+    },
+    {
       "description": "Do not update the local unpublished slogcp requirement used by examples",
       "matchManagers": ["gomod"],
       "matchFileNames": [".examples/**"],


### PR DESCRIPTION
## Summary
- add a Renovate package rule for Dockerfile-managed dependencies under .e2e/**
- enable Renovate PR automerge for that class after branch protection checks pass
- label and group future e2e Docker dependency updates separately

## Why
Trusted Renovate e2e Docker updates now run automatic cloud E2E after local validation, but Renovate still left them for manual merge because no matching package rule set automerge=true. This rule lets the same update class merge automatically after the required checks are green and Renovate reruns.

## Release impact
No version.go change. No tag or release intent.

## Validation
- python -m json.tool renovate.json
- npx --yes --package renovate@43.209.4 renovate-config-validator renovate.json
- git diff --check