### PR TITLE
fix(renovate): enable platform automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     "helpers:pinGitHubActionDigests"
   ],
   "timezone": "America/Chicago",
-  "platformAutomerge": false,
+  "platformAutomerge": true,
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["security", "security:floor", "renovate:type-security-floor"],


### PR DESCRIPTION
## Summary
- enable Renovate platform-native automerge
- keep the existing package-specific PR automerge rules unchanged

## Why
PR #20 had Renovate automerge enabled but no GitHub native auto-merge request, because the repo had `platformAutomerge` explicitly disabled. With Renovate managing the merge itself, the PR can sit until a later Renovate run sees every check run as green. Platform-native automerge delegates the merge to GitHub branch policies after required checks are satisfied, which matches Renovate's documented default behavior.

## Validation
- `python -m json.tool renovate.json`
- `git diff --check`