### PR TITLE
chore(release): bump version to v1.2.4

### DIFF
--- a/version.go
+++ b/version.go
@@ -19,7 +19,7 @@ import "fmt"
 // Version is the current version of the slogcp library.
 // Follows semantic versioning (https://semver.org/).
 // It can be overridden at build time via -ldflags.
-var Version = "v1.2.3"
+var Version = "v1.2.4"
 
 // UserAgent identifies this library when helper components need to report a
 // version string. It is initialized from Version and can be overridden at


### PR DESCRIPTION
## Summary
- bump `version.go` from `v1.2.3` to `v1.2.4`

## Release note
This prepares the v1.2.4 release branch only. Do not merge until release approval; merging to `main` will allow the auto-release workflow to create the tag and GitHub release.

## Validation
- `git diff --check`