### PR TITLE
ci: externalize GCP E2E resource names

### DIFF
--- a/.e2e/cloudbuild/cloudbuild.yaml
+++ b/.e2e/cloudbuild/cloudbuild.yaml
@@ -11,10 +11,10 @@ substitutions:
   _SHORT_SHA: ''
   _BUILD_TIME: '1970-01-01T00:00:00Z'
   _GCP_REGION: 'us-central1'
-  _ARTIFACT_REGISTRY_REPO: 'us-central1-docker.pkg.dev/slogcp/slogcp-images'
-  _GCS_BUCKET_NAME: 'slogcp-e2e-artifacts'
-  _RUNTIME_SERVICE_ACCOUNT: 'core-log-app-runtime@slogcp.iam.gserviceaccount.com'
-  _CALLER_SERVICE_ACCOUNT: 'custom-cloudbuild-runner@slogcp.iam.gserviceaccount.com'
+  _ARTIFACT_REGISTRY_REPO: '${_GCP_REGION}-docker.pkg.dev/${PROJECT_ID}/slogcp-images'
+  _GCS_BUCKET_NAME: ''
+  _RUNTIME_SERVICE_ACCOUNT: 'core-log-app-runtime@${PROJECT_ID}.iam.gserviceaccount.com'
+  _CALLER_SERVICE_ACCOUNT: 'custom-cloudbuild-runner@${PROJECT_ID}.iam.gserviceaccount.com'
   _GITHUB_TOKEN_SECRET_VERSION: ''
   _E2E_SOURCE_MODE: 'github'
   _E2E_DEPENDENCY_MODE: 'floor'
@@ -52,6 +52,10 @@ steps:
             exit 1
             ;;
         esac
+        if [ -z "${_GCS_BUCKET_NAME}" ]; then
+          echo "Error: _GCS_BUCKET_NAME is required" >&2
+          exit 1
+        fi
         echo "${_E2E_DEPENDENCY_MODE}" > /workspace/dependency_mode.txt
         echo "${_E2E_TOOLCHAIN_MODE}" > /workspace/toolchain_mode.txt
         printf '[init]\n  defaultBranch = main\n' >> ~/.gitconfig

--- a/.e2e/local/scripts/sync-env-from-gcloud.sh
+++ b/.e2e/local/scripts/sync-env-from-gcloud.sh
@@ -233,15 +233,12 @@ fi
 PROJECT_NUMBER="$(gcloud projects describe "$GCP_PROJECT_ID" --format='value(projectNumber)' 2>/dev/null || true)"
 
 if [[ -z "$GCS_BUCKET_NAME" ]]; then
-    for candidate in "${GCP_PROJECT_ID}-slogcp-e2e-artifacts" "slogcp-e2e-artifacts"; do
-        if gcloud storage buckets describe "gs://${candidate}" --project "$GCP_PROJECT_ID" >/dev/null 2>&1; then
-            GCS_BUCKET_NAME="$candidate"
-            break
-        fi
-    done
-fi
-if [[ -z "$GCS_BUCKET_NAME" ]]; then
-    GCS_BUCKET_NAME="${GCP_PROJECT_ID}-slogcp-e2e-artifacts"
+    candidate="${GCP_PROJECT_ID}-slogcp-e2e-artifacts"
+    if gcloud storage buckets describe "gs://${candidate}" --project "$GCP_PROJECT_ID" >/dev/null 2>&1; then
+        GCS_BUCKET_NAME="$candidate"
+    else
+        die "GCS bucket is required; pass --gcs-bucket-name or create gs://${candidate}"
+    fi
 fi
 
 cat > "$ENV_FILE" <<EOF

--- a/.github/scripts/run_e2e_cloud_build.sh
+++ b/.github/scripts/run_e2e_cloud_build.sh
@@ -413,7 +413,8 @@ if [[ -z "$E2E_TRUSTED_E2E_ROOT" ]]; then
     E2E_TRUSTED_E2E_ROOT=".e2e"
 fi
 if [[ -z "$GCP_PROJECT_ID" ]]; then
-    GCP_PROJECT_ID="slogcp"
+    echo "GCP_PROJECT_ID is required (set it in env or pass --project)" >&2
+    exit 1
 fi
 if [[ -z "$RUN_REGION" ]]; then
     RUN_REGION="us-central1"
@@ -422,7 +423,8 @@ if [[ -z "$ARTIFACT_REGISTRY_REPO" ]]; then
     ARTIFACT_REGISTRY_REPO="${RUN_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/slogcp-images"
 fi
 if [[ -z "$GCS_BUCKET_NAME" ]]; then
-    GCS_BUCKET_NAME="slogcp-e2e-artifacts"
+    echo "GCS_BUCKET_NAME is required (set it in env or pass --gcs-bucket-name)" >&2
+    exit 1
 fi
 if [[ -z "$E2E_SERVICE_ACCOUNT" ]]; then
     E2E_SERVICE_ACCOUNT="core-log-app-runtime@${GCP_PROJECT_ID}.iam.gserviceaccount.com"

--- a/.github/workflows/manual-e2e-trigger.yml
+++ b/.github/workflows/manual-e2e-trigger.yml
@@ -29,10 +29,10 @@ jobs:
     env:
       CHECK_RUN_NAME: E2E Tests (GCP)
       LOCAL_VALIDATION_CHECK_NAME: Local Validation Ready for E2E
-      GCS_BUCKET_NAME: slogcp-e2e-artifacts
-      GCS_SOURCE_STAGING_DIR: gs://slogcp-e2e-artifacts/cloudbuild/source
+      GCS_BUCKET_NAME: ${{ secrets.GCP_E2E_ARTIFACTS_BUCKET }}
+      GCS_SOURCE_STAGING_DIR: gs://${{ secrets.GCP_E2E_ARTIFACTS_BUCKET }}/cloudbuild/source
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-      GITHUB_TOKEN_SECRET_VERSION: projects/slogcp/secrets/GitHub-us-central1-connection-github-oauthtoken-34ff15/versions/latest
+      GITHUB_TOKEN_SECRET_VERSION: projects/${{ secrets.GCP_PROJECT_ID }}/secrets/${{ secrets.GCP_GITHUB_TOKEN_SECRET_NAME }}/versions/latest
       RUN_REGION: us-central1
 
     steps:

--- a/.github/workflows/validation_pipeline.yml
+++ b/.github/workflows/validation_pipeline.yml
@@ -462,10 +462,10 @@ jobs:
     env:
       CHECK_RUN_NAME: E2E Tests (GCP)
       LOCAL_VALIDATION_CHECK_NAME: Local Validation Ready for E2E
-      GCS_BUCKET_NAME: slogcp-e2e-artifacts
-      GCS_SOURCE_STAGING_DIR: gs://slogcp-e2e-artifacts/cloudbuild/source
+      GCS_BUCKET_NAME: ${{ secrets.GCP_E2E_ARTIFACTS_BUCKET }}
+      GCS_SOURCE_STAGING_DIR: gs://${{ secrets.GCP_E2E_ARTIFACTS_BUCKET }}/cloudbuild/source
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-      GITHUB_TOKEN_SECRET_VERSION: projects/slogcp/secrets/GitHub-us-central1-connection-github-oauthtoken-34ff15/versions/latest
+      GITHUB_TOKEN_SECRET_VERSION: projects/${{ secrets.GCP_PROJECT_ID }}/secrets/${{ secrets.GCP_GITHUB_TOKEN_SECRET_NAME }}/versions/latest
       RUN_REGION: us-central1
     concurrency:
       group: e2e-gate-${{ github.event.pull_request.number || github.run_id }}
@@ -957,7 +957,11 @@ jobs:
           steps.wait_validation.outputs.ok == 'true'
         id: have_secrets
         run: |
-          if [ -n "${{ secrets.GCP_PROJECT_ID }}" ] && [ -n "${{ secrets.GCP_WIF_PROVIDER }}" ] && [ -n "${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}" ]; then
+          if [ -n "${{ secrets.GCP_PROJECT_ID }}" ] &&
+             [ -n "${{ secrets.GCP_WIF_PROVIDER }}" ] &&
+             [ -n "${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}" ] &&
+             [ -n "${{ secrets.GCP_E2E_ARTIFACTS_BUCKET }}" ] &&
+             [ -n "${{ secrets.GCP_GITHUB_TOKEN_SECRET_NAME }}" ]; then
             echo "ok=true" >> "$GITHUB_OUTPUT"
           else
             echo "ok=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/weekly-latest-deps-e2e.yml
+++ b/.github/workflows/weekly-latest-deps-e2e.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     env:
-      GCS_BUCKET_NAME: slogcp-e2e-artifacts
-      GCS_SOURCE_STAGING_DIR: gs://slogcp-e2e-artifacts/cloudbuild/source
+      GCS_BUCKET_NAME: ${{ secrets.GCP_E2E_ARTIFACTS_BUCKET }}
+      GCS_SOURCE_STAGING_DIR: gs://${{ secrets.GCP_E2E_ARTIFACTS_BUCKET }}/cloudbuild/source
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-      GITHUB_TOKEN_SECRET_VERSION: projects/slogcp/secrets/GitHub-us-central1-connection-github-oauthtoken-34ff15/versions/latest
+      GITHUB_TOKEN_SECRET_VERSION: projects/${{ secrets.GCP_PROJECT_ID }}/secrets/${{ secrets.GCP_GITHUB_TOKEN_SECRET_NAME }}/versions/latest
       RUN_REGION: us-central1
 
     steps:


### PR DESCRIPTION
## Summary

- move CI E2E bucket and Secret Manager secret names behind GitHub repository secrets
- compose the Secret Manager version path from `GCP_PROJECT_ID` plus the new secret-name secret
- remove concrete project/bucket/service-account defaults from the Cloud Build config and helper scripts

## External setup performed

- created replacement GCS artifact bucket and copied existing artifact paths into it
- created replacement Secret Manager secret and copied the latest old secret version without printing it
- copied the old bucket lifecycle/IAM behavior and secret accessor IAM to the replacements
- added `GCP_E2E_ARTIFACTS_BUCKET` and `GCP_GITHUB_TOKEN_SECRET_NAME` to the `pjscruggs/slogcp` repository secrets

## Validation

- `actionlint .github/workflows/auto-release.yml .github/workflows/manual-e2e-trigger.yml .github/workflows/validation_pipeline.yml .github/workflows/weekly-latest-deps-e2e.yml`
- parsed all workflow YAML files plus `.e2e/cloudbuild/cloudbuild.yaml` with PyYAML
- `bash -n` via Git Bash for `.github/scripts/run_e2e_cloud_build.sh` and `.e2e/local/scripts/sync-env-from-gcloud.sh`
- `git diff --check`

## Notes

I did not start a real Cloud Build run from this branch because that would begin the long E2E wait step. The next validation step is to let the draft PR checks run, then trigger the manual E2E workflow after the branch is ready for that check.
