### PR TITLE
ci: harden GCP E2E and signed releases

### DIFF
--- a/.e2e/cloudbuild/cloudbuild.yaml
+++ b/.e2e/cloudbuild/cloudbuild.yaml
@@ -10,19 +10,19 @@ substitutions:
   _PR_NUMBER: ''
   _SHORT_SHA: ''
   _BUILD_TIME: '1970-01-01T00:00:00Z'
-  _GCP_REGION: 'us-central1'
-  _ARTIFACT_REGISTRY_REPO: '${_GCP_REGION}-docker.pkg.dev/${PROJECT_ID}/slogcp-images'
+  _GCP_REGION: ''
+  _ARTIFACT_REGISTRY_REPO: ''
   _GCS_BUCKET_NAME: ''
-  _RUNTIME_SERVICE_ACCOUNT: 'core-log-app-runtime@${PROJECT_ID}.iam.gserviceaccount.com'
-  _CALLER_SERVICE_ACCOUNT: 'custom-cloudbuild-runner@${PROJECT_ID}.iam.gserviceaccount.com'
+  _RUNTIME_SERVICE_ACCOUNT: ''
+  _CALLER_SERVICE_ACCOUNT: ''
   _GITHUB_TOKEN_SECRET_VERSION: ''
   _E2E_SOURCE_MODE: 'github'
   _E2E_DEPENDENCY_MODE: 'floor'
   _E2E_TOOLCHAIN_MODE: 'repo'
   _E2E_REPO_GO_VERSION: ''
   _SLOGCP_REF_OVERRIDE: ''
-  _TRACE_PUBSUB_TOPIC: 'slogcp-trace-pubsub'
-  _TRACE_PUBSUB_SUBSCRIPTION: 'slogcp-trace-pubsub-sub'
+  _TRACE_PUBSUB_TOPIC: ''
+  _TRACE_PUBSUB_SUBSCRIPTION: ''
   _E2E_HARNESS_TIMEOUT_SECONDS: '5400'
   _E2E_DEBUG: 'true'
   _E2E_RUN_ID: ''
@@ -54,6 +54,30 @@ steps:
         esac
         if [ -z "${_GCS_BUCKET_NAME}" ]; then
           echo "Error: _GCS_BUCKET_NAME is required" >&2
+          exit 1
+        fi
+        if [ -z "${_GCP_REGION}" ]; then
+          echo "Error: _GCP_REGION is required" >&2
+          exit 1
+        fi
+        if [ -z "${_ARTIFACT_REGISTRY_REPO}" ]; then
+          echo "Error: _ARTIFACT_REGISTRY_REPO is required" >&2
+          exit 1
+        fi
+        if [ -z "${_RUNTIME_SERVICE_ACCOUNT}" ]; then
+          echo "Error: _RUNTIME_SERVICE_ACCOUNT is required" >&2
+          exit 1
+        fi
+        if [ -z "${_CALLER_SERVICE_ACCOUNT}" ]; then
+          echo "Error: _CALLER_SERVICE_ACCOUNT is required" >&2
+          exit 1
+        fi
+        if [ -z "${_TRACE_PUBSUB_TOPIC}" ]; then
+          echo "Error: _TRACE_PUBSUB_TOPIC is required" >&2
+          exit 1
+        fi
+        if [ -z "${_TRACE_PUBSUB_SUBSCRIPTION}" ]; then
+          echo "Error: _TRACE_PUBSUB_SUBSCRIPTION is required" >&2
           exit 1
         fi
         echo "${_E2E_DEPENDENCY_MODE}" > /workspace/dependency_mode.txt
@@ -142,6 +166,12 @@ steps:
       - -c
       - |
         set -euo pipefail
+        if ! command -v python3 >/dev/null 2>&1; then
+          apt-get update
+          apt-get install -y --no-install-recommends python3
+          rm -rf /var/lib/apt/lists/*
+        fi
+
         if [ "${_E2E_TOOLCHAIN_MODE}" = "latest" ]; then
           GO_VERSION="$$(python3 scripts/resolve_latest_go_version.py)"
         else
@@ -343,6 +373,12 @@ steps:
       - -c
       - |
         set -euo pipefail
+        if ! command -v python3 >/dev/null 2>&1; then
+          apt-get update
+          apt-get install -y --no-install-recommends python3
+          rm -rf /var/lib/apt/lists/*
+        fi
+
         export PATH="/workspace/go/bin:$$PATH"
         export GO_BINARY="/workspace/go/bin/go"
         GO_VERSION="$$(cat /workspace/go_version.txt)"
@@ -673,6 +709,16 @@ steps:
             --topic "$$TRACE_PUBSUB_TOPIC_ID" \
             --project "${PROJECT_ID}"
         fi
+        gcloud pubsub topics add-iam-policy-binding "$$TRACE_PUBSUB_TOPIC_ID" \
+          --member "serviceAccount:${_RUNTIME_SERVICE_ACCOUNT}" \
+          --role roles/pubsub.publisher \
+          --project "${PROJECT_ID}" \
+          --quiet
+        gcloud pubsub subscriptions add-iam-policy-binding "$$TRACE_PUBSUB_SUBSCRIPTION_ID" \
+          --member "serviceAccount:${_RUNTIME_SERVICE_ACCOUNT}" \
+          --role roles/pubsub.subscriber \
+          --project "${PROJECT_ID}" \
+          --quiet
         trap - ERR
     id: 'Ensure trace pubsub resources'
     waitFor: ['Deploy core service', 'Push e2e-harness']

--- a/.e2e/local/.env.template
+++ b/.e2e/local/.env.template
@@ -5,15 +5,15 @@
 
 # GCP target project and region.
 GCP_PROJECT_ID=your-gcp-project-id
-RUN_REGION=us-central1
+RUN_REGION=your-gcp-region
 
 # Artifact and test artifact storage in your project.
-ARTIFACT_REGISTRY_REPO=us-central1-docker.pkg.dev/your-gcp-project-id/slogcp-images
-GCS_BUCKET_NAME=your-gcp-project-id-slogcp-e2e-artifacts
+ARTIFACT_REGISTRY_REPO=your-artifact-registry-repository-path
+GCS_BUCKET_NAME=your-gcs-artifacts-bucket
 
 # Service accounts used by the Cloud Run services and harness job.
-E2E_SERVICE_ACCOUNT=core-log-app-runtime@your-gcp-project-id.iam.gserviceaccount.com
-E2E_CALLER_SERVICE_ACCOUNT=custom-cloudbuild-runner@your-gcp-project-id.iam.gserviceaccount.com
+E2E_SERVICE_ACCOUNT=your-runtime-service-account@your-gcp-project-id.iam.gserviceaccount.com
+E2E_CALLER_SERVICE_ACCOUNT=your-cloud-build-caller-service-account@your-gcp-project-id.iam.gserviceaccount.com
 
 # Optional run metadata.
 LIB_REPO_FULL_NAME=pjscruggs/slogcp
@@ -24,5 +24,5 @@ PR_NUMBER=
 CHECK_RUN_ID=0
 
 # Optional base names for per-run Pub/Sub resources used by trace propagation tests.
-TRACE_PUBSUB_TOPIC=slogcp-trace-pubsub
-TRACE_PUBSUB_SUBSCRIPTION=slogcp-trace-pubsub-sub
+TRACE_PUBSUB_TOPIC=your-trace-pubsub-topic-base
+TRACE_PUBSUB_SUBSCRIPTION=your-trace-pubsub-subscription-base

--- a/.e2e/local/docs/GOOGLE_CLOUD_PROJECT_SETUP.md
+++ b/.e2e/local/docs/GOOGLE_CLOUD_PROJECT_SETUP.md
@@ -19,17 +19,19 @@ Set variables like these before running the setup commands:
 
 ```bash
 PROJECT_ID="your-project-id"
-REGION="us-central1"
+REGION="your-gcp-region"
 
-ARTIFACT_REPO="slogcp-images"
-ARTIFACT_REGISTRY_REPO="${REGION}-docker.pkg.dev/${PROJECT_ID}/${ARTIFACT_REPO}"
-ARTIFACT_BUCKET="${PROJECT_ID}-slogcp-e2e-artifacts"
+ARTIFACT_REPO="your-artifact-registry-repo"
+ARTIFACT_REGISTRY_REPO="your-artifact-registry-repository-path"
+ARTIFACT_BUCKET="your-gcs-artifacts-bucket"
 
-RUNTIME_SA="core-log-app-runtime@${PROJECT_ID}.iam.gserviceaccount.com"
-CALLER_SA="custom-cloudbuild-runner@${PROJECT_ID}.iam.gserviceaccount.com"
+RUNTIME_SA_NAME="your-runtime-service-account"
+CALLER_SA_NAME="your-cloud-build-caller-service-account"
+RUNTIME_SA="${RUNTIME_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+CALLER_SA="${CALLER_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 
-TRACE_TOPIC="slogcp-trace-pubsub"
-TRACE_SUBSCRIPTION="slogcp-trace-pubsub-sub"
+TRACE_TOPIC="your-trace-pubsub-topic-base"
+TRACE_SUBSCRIPTION="your-trace-pubsub-subscription-base"
 
 YOUR_MEMBER="user:you@example.com"
 ```
@@ -55,11 +57,11 @@ gcloud services enable \
 ## 2. Create Service Accounts
 
 ```bash
-gcloud iam service-accounts create core-log-app-runtime \
+gcloud iam service-accounts create "${RUNTIME_SA_NAME}" \
   --display-name "Core Logging Target App Runtime SA" \
   --project "${PROJECT_ID}"
 
-gcloud iam service-accounts create custom-cloudbuild-runner \
+gcloud iam service-accounts create "${CALLER_SA_NAME}" \
   --display-name "Custom Cloud Build Runner SA" \
   --project "${PROJECT_ID}"
 ```

--- a/.e2e/local/scripts/sync-env-from-gcloud.sh
+++ b/.e2e/local/scripts/sync-env-from-gcloud.sh
@@ -203,22 +203,22 @@ if [[ -z "$GCP_PROJECT_ID" ]]; then
     die "GCP project is required; set it in gcloud, the env file, or pass --project"
 fi
 if [[ -z "$RUN_REGION" ]]; then
-    RUN_REGION="us-central1"
+    die "Run region is required; set RUN_REGION or pass --region"
 fi
 if [[ -z "$ARTIFACT_REGISTRY_REPO" ]]; then
-    ARTIFACT_REGISTRY_REPO="${RUN_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/slogcp-images"
+    die "Artifact Registry repository is required; set ARTIFACT_REGISTRY_REPO or pass --artifact-registry-repo"
 fi
 if [[ -z "$E2E_SERVICE_ACCOUNT" ]]; then
-    E2E_SERVICE_ACCOUNT="core-log-app-runtime@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+    die "Runtime service account is required; set E2E_SERVICE_ACCOUNT or pass --runtime-service-account"
 fi
 if [[ -z "$E2E_CALLER_SERVICE_ACCOUNT" ]]; then
-    E2E_CALLER_SERVICE_ACCOUNT="custom-cloudbuild-runner@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+    die "Caller service account is required; set E2E_CALLER_SERVICE_ACCOUNT or pass --caller-service-account"
 fi
 if [[ -z "$TRACE_PUBSUB_TOPIC" ]]; then
-    TRACE_PUBSUB_TOPIC="slogcp-trace-pubsub"
+    die "Trace Pub/Sub topic is required; set TRACE_PUBSUB_TOPIC or pass --trace-pubsub-topic"
 fi
 if [[ -z "$TRACE_PUBSUB_SUBSCRIPTION" ]]; then
-    TRACE_PUBSUB_SUBSCRIPTION="slogcp-trace-pubsub-sub"
+    die "Trace Pub/Sub subscription is required; set TRACE_PUBSUB_SUBSCRIPTION or pass --trace-pubsub-subscription"
 fi
 if [[ -z "$LIB_REPO_FULL_NAME" ]]; then
     LIB_REPO_FULL_NAME="$(detect_repo_full_name)"
@@ -233,12 +233,7 @@ fi
 PROJECT_NUMBER="$(gcloud projects describe "$GCP_PROJECT_ID" --format='value(projectNumber)' 2>/dev/null || true)"
 
 if [[ -z "$GCS_BUCKET_NAME" ]]; then
-    candidate="${GCP_PROJECT_ID}-slogcp-e2e-artifacts"
-    if gcloud storage buckets describe "gs://${candidate}" --project "$GCP_PROJECT_ID" >/dev/null 2>&1; then
-        GCS_BUCKET_NAME="$candidate"
-    else
-        die "GCS bucket is required; pass --gcs-bucket-name or create gs://${candidate}"
-    fi
+    die "GCS bucket is required; set GCS_BUCKET_NAME or pass --gcs-bucket-name"
 fi
 
 cat > "$ENV_FILE" <<EOF

--- a/.e2e/services/e2e-harness/client/logging_client.go
+++ b/.e2e/services/e2e-harness/client/logging_client.go
@@ -266,6 +266,43 @@ func (c *LoggingClient) WaitForLogs(ctx context.Context, opts QueryOptions, time
 	return nil, fmt.Errorf("timeout waiting for logs after %v", timeout)
 }
 
+// WaitForLogCount queries logs with retries until at least minCount entries are
+// visible or timeout expires.
+func (c *LoggingClient) WaitForLogCount(ctx context.Context, opts QueryOptions, minCount int, timeout time.Duration) ([]*LogEntry, error) {
+	if minCount <= 0 {
+		return c.WaitForLogs(ctx, opts, timeout)
+	}
+
+	deadline := time.Now().Add(timeout)
+	backoff := 1 * time.Second
+	maxBackoff := 10 * time.Second
+	lastCount := 0
+
+	for time.Now().Before(deadline) {
+		entries, err := c.QueryLogs(ctx, opts)
+		if err != nil {
+			return nil, fmt.Errorf("querying logs: %w", err)
+		}
+
+		if len(entries) >= minCount {
+			return entries, nil
+		}
+		lastCount = len(entries)
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("waiting for %d logs canceled after finding %d: %w", minCount, lastCount, ctx.Err())
+		case <-time.After(backoff):
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("timeout waiting for at least %d logs after %v; found %d", minCount, timeout, lastCount)
+}
+
 // WaitForLogsJSON queries Cloud Logging via the REST API with retries until entries
 // are found or timeout.
 func (c *LoggingClient) WaitForLogsJSON(ctx context.Context, opts QueryOptions, timeout time.Duration) ([]map[string]any, error) {

--- a/.e2e/services/e2e-harness/main.go
+++ b/.e2e/services/e2e-harness/main.go
@@ -47,8 +47,8 @@ type imageConfig struct {
 
 const (
 	separatorLine                  = "------------------------------------------------------------------------"
-	defaultTracePubSubTopic        = "slogcp-trace-pubsub"
-	defaultTracePubSubSubscription = "slogcp-trace-pubsub-sub"
+	defaultTracePubSubTopic        = "trace-pubsub"
+	defaultTracePubSubSubscription = "trace-pubsub-sub"
 	defaultHarnessTimeout          = 25 * time.Minute
 	maxPubSubResourceIDLength      = 255
 )

--- a/.e2e/services/e2e-harness/tests/core_logging.go
+++ b/.e2e/services/e2e-harness/tests/core_logging.go
@@ -1340,12 +1340,13 @@ func (s *CoreLoggingTestSuite) testBatchLogging(ctx context.Context) error {
 	log.Println("Testing batch logging")
 
 	testID := fmt.Sprintf("%s-batch-%d", s.testRunID, time.Now().UnixNano())
+	const batchSize = 5
 
 	req := client.LogRequest{
 		Message: "Batch logging test",
 		TestID:  testID,
 		Attributes: map[string]any{
-			"batch_size": 5,
+			"batch_size": batchSize,
 		},
 	}
 
@@ -1356,19 +1357,14 @@ func (s *CoreLoggingTestSuite) testBatchLogging(ctx context.Context) error {
 
 	// Query logs - should find multiple entries
 	filter := fmt.Sprintf(`jsonPayload.test_id="%s"`, testID)
-	entries, err := s.loggingClient.WaitForLogs(ctx, client.QueryOptions{
+	entries, err := s.loggingClient.WaitForLogCount(ctx, client.QueryOptions{
 		Filter:     filter,
 		StartTime:  time.Now().Add(-1 * time.Minute),
 		MaxResults: 10,
-	}, logWaitTimeout)
+	}, batchSize, logWaitTimeout)
 
 	if err != nil {
 		return fmt.Errorf("failed to find batch logs: %w", err)
-	}
-
-	// We expect at least 5 logs from the batch
-	if len(entries) < 5 {
-		return fmt.Errorf("expected at least 5 logs from batch, got %d", len(entries))
 	}
 
 	// Validate each has proper structure

--- a/.github/scripts/run_e2e_cloud_build.sh
+++ b/.github/scripts/run_e2e_cloud_build.sh
@@ -566,7 +566,7 @@ if [[ -n "$E2E_REPO_GO_VERSION" ]]; then
     echo "Repo Go version: ${E2E_REPO_GO_VERSION}"
 fi
 if [[ -n "$GCS_SOURCE_STAGING_DIR" ]]; then
-    echo "Source staging dir: ${GCS_SOURCE_STAGING_DIR}"
+    echo "Using configured Cloud Build source staging directory."
 fi
 
 submit_args=(
@@ -588,7 +588,6 @@ fi
 
 submit_output=""
 if ! submit_output="$(gcloud builds submit "${submit_args[@]}" 2>&1)"; then
-    printf '%s\n' "$submit_output" >&2
     echo "Failed to start Cloud Build." >&2
     emit_outputs
     exit 1
@@ -606,15 +605,13 @@ if [[ -z "$BUILD_ID" ]]; then
 fi
 
 if [[ -z "$BUILD_ID" ]]; then
-    printf '%s\n' "$submit_output" >&2
     echo "Failed to start Cloud Build and resolve build ID." >&2
     emit_outputs
     exit 1
 fi
 
 BUILD_LOG_URL="https://console.cloud.google.com/cloud-build/builds/${BUILD_ID}?project=${GCP_PROJECT_ID}"
-echo "Cloud Build started: ${BUILD_ID}"
-echo "Logs: ${BUILD_LOG_URL}"
+echo "Cloud Build started."
 
 if [[ "$E2E_NO_WAIT" == "true" ]]; then
     BUILD_STATUS="$(gcloud builds describe "$BUILD_ID" --project="$GCP_PROJECT_ID" --region="$RUN_REGION" --format='value(status)' 2>/dev/null || true)"

--- a/.github/scripts/run_e2e_cloud_build.sh
+++ b/.github/scripts/run_e2e_cloud_build.sh
@@ -417,26 +417,32 @@ if [[ -z "$GCP_PROJECT_ID" ]]; then
     exit 1
 fi
 if [[ -z "$RUN_REGION" ]]; then
-    RUN_REGION="us-central1"
+    echo "RUN_REGION is required (set it in env or pass --region)" >&2
+    exit 1
 fi
 if [[ -z "$ARTIFACT_REGISTRY_REPO" ]]; then
-    ARTIFACT_REGISTRY_REPO="${RUN_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/slogcp-images"
+    echo "ARTIFACT_REGISTRY_REPO is required (set it in env or pass --artifact-registry-repo)" >&2
+    exit 1
 fi
 if [[ -z "$GCS_BUCKET_NAME" ]]; then
     echo "GCS_BUCKET_NAME is required (set it in env or pass --gcs-bucket-name)" >&2
     exit 1
 fi
 if [[ -z "$E2E_SERVICE_ACCOUNT" ]]; then
-    E2E_SERVICE_ACCOUNT="core-log-app-runtime@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+    echo "E2E_SERVICE_ACCOUNT is required (set it in env or pass --runtime-service-account)" >&2
+    exit 1
 fi
 if [[ -z "$E2E_CALLER_SERVICE_ACCOUNT" ]]; then
-    E2E_CALLER_SERVICE_ACCOUNT="custom-cloudbuild-runner@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+    echo "E2E_CALLER_SERVICE_ACCOUNT is required (set it in env or pass --caller-service-account)" >&2
+    exit 1
 fi
 if [[ -z "$TRACE_PUBSUB_TOPIC" ]]; then
-    TRACE_PUBSUB_TOPIC="slogcp-trace-pubsub"
+    echo "TRACE_PUBSUB_TOPIC is required (set it in env or pass --trace-pubsub-topic)" >&2
+    exit 1
 fi
 if [[ -z "$TRACE_PUBSUB_SUBSCRIPTION" ]]; then
-    TRACE_PUBSUB_SUBSCRIPTION="slogcp-trace-pubsub-sub"
+    echo "TRACE_PUBSUB_SUBSCRIPTION is required (set it in env or pass --trace-pubsub-subscription)" >&2
+    exit 1
 fi
 if [[ -z "$LIB_REPO_FULL_NAME" ]]; then
     LIB_REPO_FULL_NAME="$(derive_repo_full_name)"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,14 +4,24 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+    inputs:
+      version:
+        description: Optional explicit release version, for example v1.2.5.
+        required: false
+        type: string
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: auto-release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release:
-    name: Tag And Release Version
+    name: Create Signed Tag And Release
     runs-on: ubuntu-latest
+    environment: release-tags
     steps:
       - name: Checkout Code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -25,74 +35,262 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BEFORE_SHA: ${{ github.event.before }}
+          INPUT_VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
+          should_release=false
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            echo "should_release=true" >> "$GITHUB_OUTPUT"
-            echo "Manual dispatch requested release evaluation."
+            should_release=true
+          elif [[ -n "$BEFORE_SHA" && "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]]; then
+            if ! git diff --quiet "$BEFORE_SHA" "$GITHUB_SHA" -- version.go; then
+              should_release=true
+            fi
+          fi
+
+          if [[ "$should_release" != "true" ]]; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "No release intent detected."
             exit 0
           fi
 
-          if [[ -z "$BEFORE_SHA" || "$BEFORE_SHA" == "0000000000000000000000000000000000000000" ]]; then
-            echo "should_release=false" >> "$GITHUB_OUTPUT"
-            echo "No stable previous commit was available; skipping automatic release."
-            exit 0
-          fi
-
-          if git diff --quiet "$BEFORE_SHA" "$GITHUB_SHA" -- version.go; then
-            echo "should_release=false" >> "$GITHUB_OUTPUT"
-            echo "version.go did not change in this push; skipping automatic release."
-          else
-            echo "should_release=true" >> "$GITHUB_OUTPUT"
-            echo "version.go changed in this push; release evaluation will continue."
-          fi
-
-      - name: Read Version
-        id: version
-        if: steps.release_intent.outputs.should_release == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          version="$(sed -nE 's/^var Version = "(v[0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' version.go | head -n 1)"
-          if [[ -z "$version" ]]; then
+          file_version="$(sed -nE 's/^var Version = "(v[0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' version.go | head -n 1)"
+          if [[ -z "$file_version" ]]; then
             echo "Unable to parse Version from version.go" >&2
             exit 1
           fi
 
-          if git rev-parse -q --verify "refs/tags/$version" >/dev/null; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Tag $version already exists; release creation is skipped."
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
+          version="$file_version"
+          if [[ -n "${INPUT_VERSION:-}" ]]; then
+            version="$INPUT_VERSION"
           fi
+
+          if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release version must match vMAJOR.MINOR.PATCH, got: $version" >&2
+            exit 1
+          fi
+
+          if [[ "$version" != "$file_version" ]]; then
+            echo "Requested release version $version does not match version.go $file_version" >&2
+            exit 1
+          fi
+
+          if gh api "repos/${REPOSITORY}/git/ref/tags/${version}" >/dev/null 2>&1; then
+            echo "Release tag already exists: $version" >&2
+            exit 1
+          fi
+
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Create Tag And GitHub Release
-        if: steps.release_intent.outputs.should_release == 'true' && steps.version.outputs.exists == 'false'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      - name: Verify Release Configuration
+        if: steps.release_intent.outputs.should_release == 'true'
+        shell: bash
+        env:
+          RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID || secrets.E2E_APP_ID }}
+          RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY || secrets.E2E_APP_PRIVATE_KEY }}
+          RELEASE_SSH_PRIVATE_KEY_B64: ${{ secrets.RELEASE_SSH_PRIVATE_KEY_B64 }}
+          RELEASE_SSH_PUBLIC_KEY: ${{ secrets.RELEASE_SSH_PUBLIC_KEY }}
+          RELEASE_SIGNER_EMAIL: ${{ vars.RELEASE_SIGNER_EMAIL }}
+          RELEASE_SIGNER_NAME: ${{ vars.RELEASE_SIGNER_NAME }}
+        run: |
+          set -euo pipefail
+
+          missing=()
+          [[ -n "${RELEASE_APP_ID:-}" ]] || missing+=("RELEASE_APP_ID or E2E_APP_ID")
+          [[ -n "${RELEASE_APP_PRIVATE_KEY:-}" ]] || missing+=("RELEASE_APP_PRIVATE_KEY or E2E_APP_PRIVATE_KEY")
+          [[ -n "${RELEASE_SSH_PRIVATE_KEY_B64:-}" ]] || missing+=("RELEASE_SSH_PRIVATE_KEY_B64")
+          [[ -n "${RELEASE_SSH_PUBLIC_KEY:-}" ]] || missing+=("RELEASE_SSH_PUBLIC_KEY")
+          [[ -n "${RELEASE_SIGNER_EMAIL:-}" ]] || missing+=("RELEASE_SIGNER_EMAIL")
+          [[ -n "${RELEASE_SIGNER_NAME:-}" ]] || missing+=("RELEASE_SIGNER_NAME")
+
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing release configuration: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Generate Release App Token
+        if: steps.release_intent.outputs.should_release == 'true'
+        id: release_app_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const version = '${{ steps.version.outputs.version }}';
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const sha = context.sha;
+          app-id: ${{ secrets.RELEASE_APP_ID || secrets.E2E_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY || secrets.E2E_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
 
-            await github.rest.git.createRef({
-              owner,
-              repo,
-              ref: `refs/tags/${version}`,
-              sha
-            });
+      - name: Configure SSH Tag Signing
+        if: steps.release_intent.outputs.should_release == 'true'
+        id: signing
+        shell: bash
+        env:
+          RELEASE_SIGNER_EMAIL: ${{ vars.RELEASE_SIGNER_EMAIL }}
+          RELEASE_SIGNER_NAME: ${{ vars.RELEASE_SIGNER_NAME }}
+          RELEASE_SSH_PRIVATE_KEY_B64: ${{ secrets.RELEASE_SSH_PRIVATE_KEY_B64 }}
+          RELEASE_SSH_PUBLIC_KEY: ${{ secrets.RELEASE_SSH_PUBLIC_KEY }}
+        run: |
+          set -euo pipefail
 
-            await github.rest.repos.createRelease({
-              owner,
-              repo,
-              tag_name: version,
-              target_commitish: sha,
-              name: version,
-              generate_release_notes: true
-            });
+          key_file="$RUNNER_TEMP/release_signing_key"
+          public_key_file="${key_file}.pub"
+          allowed_signers="$RUNNER_TEMP/allowed_signers"
 
-            core.info(`Created ${version} for ${sha}.`);
+          printf '%s' "$RELEASE_SSH_PRIVATE_KEY_B64" | base64 -d > "$key_file"
+          printf '%s\n' "$RELEASE_SSH_PUBLIC_KEY" > "$public_key_file"
+          chmod 600 "$key_file"
+          ssh-keygen -y -f "$key_file" >/dev/null
+
+          printf '%s %s\n' "$RELEASE_SIGNER_EMAIL" "$RELEASE_SSH_PUBLIC_KEY" > "$allowed_signers"
+
+          git config user.name "$RELEASE_SIGNER_NAME"
+          git config user.email "$RELEASE_SIGNER_EMAIL"
+          git config gpg.format ssh
+          git config user.signingkey "$key_file"
+          git config gpg.ssh.allowedSignersFile "$allowed_signers"
+          git config tag.gpgSign true
+
+          echo "key_file=$key_file" >> "$GITHUB_OUTPUT"
+          echo "public_key_file=$public_key_file" >> "$GITHUB_OUTPUT"
+          echo "allowed_signers=$allowed_signers" >> "$GITHUB_OUTPUT"
+
+      - name: Create Signed Annotated Tag
+        if: steps.release_intent.outputs.should_release == 'true'
+        shell: bash
+        env:
+          VERSION: ${{ steps.release_intent.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          git tag -s "$VERSION" -m "Release $VERSION"
+          git tag -v "$VERSION"
+
+      - name: Push Release Tag
+        if: steps.release_intent.outputs.should_release == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.release_app_token.outputs.token }}
+          VERSION: ${{ steps.release_intent.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          gh api "repos/${GITHUB_REPOSITORY}" --jq .full_name >/dev/null
+          gh auth setup-git
+          git push "https://github.com/${GITHUB_REPOSITORY}.git" "refs/tags/$VERSION"
+
+      - name: Remove Signing Key Material
+        if: always() && steps.signing.outcome == 'success'
+        shell: bash
+        env:
+          KEY_FILE: ${{ steps.signing.outputs.key_file }}
+          PUBLIC_KEY_FILE: ${{ steps.signing.outputs.public_key_file }}
+          ALLOWED_SIGNERS: ${{ steps.signing.outputs.allowed_signers }}
+        run: |
+          set -euo pipefail
+
+          rm -f "$KEY_FILE" "$PUBLIC_KEY_FILE" "$ALLOWED_SIGNERS"
+
+      - name: Confirm GitHub Verified The Tag
+        if: steps.release_intent.outputs.should_release == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.release_app_token.outputs.token }}
+          VERSION: ${{ steps.release_intent.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          ref_json="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${VERSION}")"
+          ref_type="$(jq -r '.object.type' <<<"$ref_json")"
+          tag_sha="$(jq -r '.object.sha' <<<"$ref_json")"
+
+          if [[ "$ref_type" != "tag" ]]; then
+            echo "Release tag must be an annotated tag object, got ref object type: $ref_type" >&2
+            exit 1
+          fi
+
+          tag_json="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_sha}")"
+          object_type="$(jq -r '.object.type' <<<"$tag_json")"
+          commit_sha="$(jq -r '.object.sha' <<<"$tag_json")"
+          verified="$(jq -r '.verification.verified' <<<"$tag_json")"
+          reason="$(jq -r '.verification.reason' <<<"$tag_json")"
+
+          if [[ "$object_type" != "commit" ]]; then
+            echo "Release tag must point to a commit, got object type: $object_type" >&2
+            exit 1
+          fi
+
+          if [[ "$commit_sha" != "$GITHUB_SHA" ]]; then
+            echo "Release tag points at $commit_sha, expected $GITHUB_SHA" >&2
+            exit 1
+          fi
+
+          if [[ "$verified" != "true" || "$reason" != "valid" ]]; then
+            echo "GitHub does not consider tag verified: verified=$verified reason=$reason" >&2
+            exit 1
+          fi
+
+      - name: Determine Go Version
+        if: steps.release_intent.outputs.should_release == 'true' && github.event.repository.private == false
+        id: go-version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          go_version="$(awk '$1 == "go" {print $2; exit}' go.mod)"
+          if [[ -z "$go_version" ]]; then
+            echo "Unable to determine Go version from go.mod" >&2
+            exit 1
+          fi
+
+          GO_VERSION="$go_version" python3 .github/scripts/resolve_go_version.py
+
+      - name: Set Up Go
+        if: steps.release_intent.outputs.should_release == 'true' && github.event.repository.private == false
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: ${{ steps.go-version.outputs.version }}
+          cache: false
+
+      - name: Request Go Proxy Indexing
+        if: steps.release_intent.outputs.should_release == 'true' && github.event.repository.private == false
+        shell: bash
+        env:
+          VERSION: ${{ steps.release_intent.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          module_path="$(awk '$1 == "module" {print $2; exit}' go.mod)"
+          if [[ -z "$module_path" ]]; then
+            echo "Unable to determine module path from go.mod" >&2
+            exit 1
+          fi
+
+          for attempt in {1..12}; do
+            if GOPROXY=proxy.golang.org go list -m "${module_path}@${VERSION}"; then
+              exit 0
+            fi
+
+            echo "Go proxy has not resolved ${VERSION} yet; retrying (${attempt}/12)."
+            sleep 10
+          done
+
+          echo "Go proxy did not resolve ${VERSION} after retries." >&2
+          exit 1
+
+      - name: Create GitHub Release
+        if: steps.release_intent.outputs.should_release == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.release_app_token.outputs.token }}
+          VERSION: ${{ steps.release_intent.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          gh release create "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --generate-notes \
+            --title "$VERSION" \
+            --fail-on-no-commits

--- a/.github/workflows/manual-e2e-trigger.yml
+++ b/.github/workflows/manual-e2e-trigger.yml
@@ -33,7 +33,12 @@ jobs:
       GCS_SOURCE_STAGING_DIR: gs://${{ secrets.GCP_E2E_ARTIFACTS_BUCKET }}/cloudbuild/source
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       GITHUB_TOKEN_SECRET_VERSION: projects/${{ secrets.GCP_PROJECT_ID }}/secrets/${{ secrets.GCP_GITHUB_TOKEN_SECRET_NAME }}/versions/latest
-      RUN_REGION: us-central1
+      ARTIFACT_REGISTRY_REPO: ${{ secrets.GCP_E2E_ARTIFACT_REGISTRY_REPO }}
+      E2E_SERVICE_ACCOUNT: ${{ secrets.GCP_E2E_RUNTIME_SERVICE_ACCOUNT_EMAIL }}
+      E2E_CALLER_SERVICE_ACCOUNT: ${{ secrets.GCP_E2E_CLOUD_BUILD_SERVICE_ACCOUNT_EMAIL }}
+      TRACE_PUBSUB_TOPIC: ${{ secrets.GCP_E2E_TRACE_PUBSUB_TOPIC }}
+      TRACE_PUBSUB_SUBSCRIPTION: ${{ secrets.GCP_E2E_TRACE_PUBSUB_SUBSCRIPTION }}
+      RUN_REGION: ${{ secrets.GCP_E2E_RUN_REGION }}
 
     steps:
       - name: Verify Authorization
@@ -264,8 +269,8 @@ jobs:
         if: ${{ steps.target.outputs.pr_number == '' || steps.local_validation_gate.outputs.ok == 'true' }}
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
-          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          workload_identity_provider: ${{ secrets.GCP_MANUAL_E2E_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_MANUAL_E2E_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Set up Cloud SDK
         if: ${{ steps.target.outputs.pr_number == '' || steps.local_validation_gate.outputs.ok == 'true' }}
@@ -291,6 +296,11 @@ jobs:
           E2E_RUN_ID: ${{ steps.run_id.outputs.e2e_run_id }}
           GCP_PROJECT_ID: ${{ env.GCP_PROJECT_ID }}
           GITHUB_TOKEN_SECRET_VERSION: ${{ env.GITHUB_TOKEN_SECRET_VERSION }}
+          ARTIFACT_REGISTRY_REPO: ${{ env.ARTIFACT_REGISTRY_REPO }}
+          E2E_SERVICE_ACCOUNT: ${{ env.E2E_SERVICE_ACCOUNT }}
+          E2E_CALLER_SERVICE_ACCOUNT: ${{ env.E2E_CALLER_SERVICE_ACCOUNT }}
+          TRACE_PUBSUB_TOPIC: ${{ env.TRACE_PUBSUB_TOPIC }}
+          TRACE_PUBSUB_SUBSCRIPTION: ${{ env.TRACE_PUBSUB_SUBSCRIPTION }}
           RUN_REGION: ${{ env.RUN_REGION }}
           GCS_BUCKET_NAME: ${{ env.GCS_BUCKET_NAME }}
           GCS_SOURCE_STAGING_DIR: ${{ env.GCS_SOURCE_STAGING_DIR }}

--- a/.github/workflows/manual-e2e-trigger.yml
+++ b/.github/workflows/manual-e2e-trigger.yml
@@ -325,9 +325,7 @@ jobs:
           github-token: ${{ steps.final_app_token.outputs.token }}
           script: |
             const buildStatus = '${{ steps.cloud_build.outputs.build_status }}'.toUpperCase();
-            const buildId = '${{ steps.cloud_build.outputs.build_id }}';
-            const buildLogUrl = '${{ steps.cloud_build.outputs.build_log_url }}';
-            const artifactsUrl = '${{ steps.cloud_build.outputs.artifacts_url }}';
+            const detailsUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             let conclusion = 'failure';
             if (buildStatus === 'SUCCESS') {
@@ -338,16 +336,14 @@ jobs:
 
             const summaryLines = [
               `Google Cloud Build E2E tests finished: **${buildStatus || 'UNKNOWN'}**.`,
-              buildId ? `Build ID: ${buildId}` : null,
-              buildLogUrl ? `[View Cloud Build Logs](${buildLogUrl})` : null,
-              artifactsUrl ? `[Browse Test Artifacts in GCS](${artifactsUrl})` : null
+              'Maintainers can inspect internal Cloud Build logs and artifacts from Google Cloud.'
             ].filter(Boolean);
 
             await github.rest.checks.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
               check_run_id: Number('${{ steps.create_check.outputs.check_run_id }}'),
-              details_url: buildLogUrl || undefined,
+              details_url: detailsUrl,
               external_id: '${{ steps.run_id.outputs.e2e_run_id }}',
               status: 'completed',
               conclusion,

--- a/.github/workflows/validation_pipeline.yml
+++ b/.github/workflows/validation_pipeline.yml
@@ -1086,9 +1086,7 @@ jobs:
             const checkRunId = Number('${{ steps.create_run_check.outputs.check_run_id }}') || 0;
             const runId = '${{ steps.run_id.outputs.e2e_run_id }}';
             const buildStatus = '${{ steps.cloud_build.outputs.build_status }}'.toUpperCase();
-            const buildId = '${{ steps.cloud_build.outputs.build_id }}';
-            const buildLogUrl = '${{ steps.cloud_build.outputs.build_log_url }}';
-            const artifactsUrl = '${{ steps.cloud_build.outputs.artifacts_url }}';
+            const detailsUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             let conclusion = 'failure';
             if (buildStatus === 'SUCCESS') {
@@ -1099,16 +1097,14 @@ jobs:
 
             const summaryLines = [
               `Google Cloud Build E2E run \`${runId}\` finished: **${buildStatus || 'UNKNOWN'}**.`,
-              buildId ? `Build ID: ${buildId}` : null,
-              buildLogUrl ? `[View Cloud Build Logs](${buildLogUrl})` : null,
-              artifactsUrl ? `[Browse Test Artifacts in GCS](${artifactsUrl})` : null
+              'Maintainers can inspect internal Cloud Build logs and artifacts from Google Cloud.'
             ].filter(Boolean);
 
             await github.rest.checks.update({
               owner,
               repo,
               check_run_id: checkRunId,
-              details_url: buildLogUrl || undefined,
+              details_url: detailsUrl,
               external_id: runId,
               status: 'completed',
               conclusion,

--- a/.github/workflows/validation_pipeline.yml
+++ b/.github/workflows/validation_pipeline.yml
@@ -116,8 +116,6 @@ jobs:
     # Skip validation on pull_request_target to avoid running the full pipeline twice per PR update.
     if: github.event_name != 'pull_request_target' && needs.classify_validation_scope.outputs.mode != 'ci_only' && needs.classify_validation_scope.outputs.mode != 'automation_config_only'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     env:
       GOTOOLCHAIN: auto
     steps:
@@ -183,11 +181,10 @@ jobs:
           cache: true
 
       - name: 🛠️ Install golangci-lint
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
-        with:
-          version: v2.12.2
-          install-mode: goinstall
-          install-only: true
+        run: |
+          # renovate: datasource=go depName=github.com/golangci/golangci-lint/v2 versioning=semver
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
           
       - name: 🧰 Install format/modernize tools
         run: |
@@ -195,6 +192,8 @@ jobs:
           go install golang.org/x/tools/cmd/goimports@v0.45.0
           # renovate: datasource=go depName=golang.org/x/tools/gopls versioning=semver
           go install golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@v0.22.0
+          # renovate: datasource=go depName=github.com/apache/skywalking-eyes versioning=semver
+          go install github.com/apache/skywalking-eyes/cmd/license-eye@v0.8.0
 
       - name: ✨ Apply Go formatting
         run: gofmt -w .
@@ -249,11 +248,7 @@ jobs:
       
       - name: 📄🩹 Fix License Headers
         id: fix-license
-        uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
-        with:
-          mode: fix
-          config: .licenserc.yaml
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: license-eye header fix -c .licenserc.yaml
 
       - name: ♻️ Restore Go toolchain (post-license-fix)
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -265,27 +260,50 @@ jobs:
         run: golangci-lint run --fix ./...
         continue-on-error: true
       
-      - name: 💾 Commit All Fixes
+      - name: Generate Maintenance Push Token
         if: steps.maintenance-policy.outputs.allow_push == 'true'
+        id: maintenance_push_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.E2E_APP_ID }}
+          private-key: ${{ secrets.E2E_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
+      - name: 💾 Commit All Fixes
+        id: commit-fixes
+        if: steps.maintenance-policy.outputs.allow_push == 'true'
+        env:
+          BRANCH_NAME: ${{ steps.get-branch.outputs.BRANCH_NAME }}
+          GH_TOKEN: ${{ steps.maintenance_push_token.outputs.token }}
         run: |
+          set -euo pipefail
+
+          git check-ref-format --branch "$BRANCH_NAME" >/dev/null
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git diff --quiet || {
-            git add .
-            git commit -m "chore: apply code maintenance (formatting, linting, license headers)"
-            git push origin ${{ steps.get-branch.outputs.BRANCH_NAME }}
-          }
+          if git diff --quiet; then
+            echo "committed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git add .
+          git commit -m "chore: apply code maintenance (formatting, linting, license headers)"
+          gh auth setup-git
+          git push origin "HEAD:refs/heads/${BRANCH_NAME}"
+          echo "committed=true" >> "$GITHUB_OUTPUT"
           
       - name: 🔄 Re-checkout after fixes if needed
-        if: steps.maintenance-policy.outputs.allow_push == 'true'
+        if: steps.maintenance-policy.outputs.allow_push == 'true' && steps.commit-fixes.outputs.committed == 'true'
+        env:
+          BRANCH_NAME: ${{ steps.get-branch.outputs.BRANCH_NAME }}
         run: |
-          if git diff --quiet origin/${{ steps.get-branch.outputs.BRANCH_NAME }} HEAD; then
-            echo "No changes were committed, skipping re-checkout"
-          else
-            echo "Changes were committed, re-checking out latest code"
-            git fetch
-            git checkout origin/${{ steps.get-branch.outputs.BRANCH_NAME }}
-          fi
+          set -euo pipefail
+
+          git check-ref-format --branch "$BRANCH_NAME" >/dev/null
+          git fetch origin "refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}"
+          git checkout --detach "refs/remotes/origin/${BRANCH_NAME}"
 
       - name: ✅ Ensure working tree is clean
         run: |
@@ -310,11 +328,7 @@ jobs:
         run: golangci-lint run ./...
       
       - name: 📄✅ Verify License Headers
-        uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
-        with:
-          mode: check
-          config: .licenserc.yaml
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: license-eye header check -c .licenserc.yaml
 
       - name: ✅ Verify example Go directives
         if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'renovate:go-version')
@@ -466,16 +480,21 @@ jobs:
       GCS_SOURCE_STAGING_DIR: gs://${{ secrets.GCP_E2E_ARTIFACTS_BUCKET }}/cloudbuild/source
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       GITHUB_TOKEN_SECRET_VERSION: projects/${{ secrets.GCP_PROJECT_ID }}/secrets/${{ secrets.GCP_GITHUB_TOKEN_SECRET_NAME }}/versions/latest
-      RUN_REGION: us-central1
+      ARTIFACT_REGISTRY_REPO: ${{ secrets.GCP_E2E_ARTIFACT_REGISTRY_REPO }}
+      E2E_SERVICE_ACCOUNT: ${{ secrets.GCP_E2E_RUNTIME_SERVICE_ACCOUNT_EMAIL }}
+      E2E_CALLER_SERVICE_ACCOUNT: ${{ secrets.GCP_E2E_CLOUD_BUILD_SERVICE_ACCOUNT_EMAIL }}
+      TRACE_PUBSUB_TOPIC: ${{ secrets.GCP_E2E_TRACE_PUBSUB_TOPIC }}
+      TRACE_PUBSUB_SUBSCRIPTION: ${{ secrets.GCP_E2E_TRACE_PUBSUB_SUBSCRIPTION }}
+      RUN_REGION: ${{ secrets.GCP_E2E_RUN_REGION }}
     concurrency:
       group: e2e-gate-${{ github.event.pull_request.number || github.run_id }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 180
     permissions:
-      checks: write
-      contents: write
-      pull-requests: write
+      checks: read
+      contents: read
+      pull-requests: read
       id-token: write
     
     steps:
@@ -597,6 +616,8 @@ jobs:
           private-key: ${{ secrets.E2E_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: read
 
       - name: Ensure security floor release version is committed
         if: |
@@ -721,6 +742,7 @@ jobs:
           private-key: ${{ secrets.E2E_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-checks: write
 
       - name: Finalize E2E check for no-cloud manual PRs
         if: |
@@ -958,10 +980,16 @@ jobs:
         id: have_secrets
         run: |
           if [ -n "${{ secrets.GCP_PROJECT_ID }}" ] &&
-             [ -n "${{ secrets.GCP_WIF_PROVIDER }}" ] &&
-             [ -n "${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}" ] &&
+             [ -n "${{ secrets.GCP_VALIDATION_E2E_WIF_PROVIDER }}" ] &&
+             [ -n "${{ secrets.GCP_VALIDATION_E2E_SERVICE_ACCOUNT_EMAIL }}" ] &&
              [ -n "${{ secrets.GCP_E2E_ARTIFACTS_BUCKET }}" ] &&
-             [ -n "${{ secrets.GCP_GITHUB_TOKEN_SECRET_NAME }}" ]; then
+             [ -n "${{ secrets.GCP_GITHUB_TOKEN_SECRET_NAME }}" ] &&
+             [ -n "${{ secrets.GCP_E2E_ARTIFACT_REGISTRY_REPO }}" ] &&
+             [ -n "${{ secrets.GCP_E2E_RUNTIME_SERVICE_ACCOUNT_EMAIL }}" ] &&
+             [ -n "${{ secrets.GCP_E2E_CLOUD_BUILD_SERVICE_ACCOUNT_EMAIL }}" ] &&
+             [ -n "${{ secrets.GCP_E2E_TRACE_PUBSUB_TOPIC }}" ] &&
+             [ -n "${{ secrets.GCP_E2E_TRACE_PUBSUB_SUBSCRIPTION }}" ] &&
+             [ -n "${{ secrets.GCP_E2E_RUN_REGION }}" ]; then
             echo "ok=true" >> "$GITHUB_OUTPUT"
           else
             echo "ok=false" >> "$GITHUB_OUTPUT"
@@ -976,8 +1004,8 @@ jobs:
           steps.have_secrets.outputs.ok == 'true'
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
-          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          workload_identity_provider: ${{ secrets.GCP_VALIDATION_E2E_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_VALIDATION_E2E_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Set up Cloud SDK
         if: |
@@ -1013,6 +1041,11 @@ jobs:
           E2E_RUN_ID: ${{ steps.run_id.outputs.e2e_run_id }}
           GCP_PROJECT_ID: ${{ env.GCP_PROJECT_ID }}
           GITHUB_TOKEN_SECRET_VERSION: ${{ env.GITHUB_TOKEN_SECRET_VERSION }}
+          ARTIFACT_REGISTRY_REPO: ${{ env.ARTIFACT_REGISTRY_REPO }}
+          E2E_SERVICE_ACCOUNT: ${{ env.E2E_SERVICE_ACCOUNT }}
+          E2E_CALLER_SERVICE_ACCOUNT: ${{ env.E2E_CALLER_SERVICE_ACCOUNT }}
+          TRACE_PUBSUB_TOPIC: ${{ env.TRACE_PUBSUB_TOPIC }}
+          TRACE_PUBSUB_SUBSCRIPTION: ${{ env.TRACE_PUBSUB_SUBSCRIPTION }}
           RUN_REGION: ${{ env.RUN_REGION }}
           GCS_BUCKET_NAME: ${{ env.GCS_BUCKET_NAME }}
           GCS_SOURCE_STAGING_DIR: ${{ env.GCS_SOURCE_STAGING_DIR }}
@@ -1033,6 +1066,7 @@ jobs:
           private-key: ${{ secrets.E2E_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-checks: write
 
       - name: Finalize stable E2E check after Cloud Build
         if: |
@@ -1119,6 +1153,8 @@ jobs:
           private-key: ${{ secrets.E2E_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Auto-merge security floor PR after E2E
         if: |
@@ -1205,6 +1241,7 @@ jobs:
           private-key: ${{ secrets.E2E_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-checks: write
 
       - name: Finalize stable E2E check for updates that do not require cloud E2E
         if: |
@@ -1264,6 +1301,7 @@ jobs:
           private-key: ${{ secrets.E2E_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-checks: write
 
       - name: Update stable E2E check when auto path cannot run
         if: |

--- a/.github/workflows/weekly-latest-deps-e2e.yml
+++ b/.github/workflows/weekly-latest-deps-e2e.yml
@@ -19,7 +19,12 @@ jobs:
       GCS_SOURCE_STAGING_DIR: gs://${{ secrets.GCP_E2E_ARTIFACTS_BUCKET }}/cloudbuild/source
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       GITHUB_TOKEN_SECRET_VERSION: projects/${{ secrets.GCP_PROJECT_ID }}/secrets/${{ secrets.GCP_GITHUB_TOKEN_SECRET_NAME }}/versions/latest
-      RUN_REGION: us-central1
+      ARTIFACT_REGISTRY_REPO: ${{ secrets.GCP_E2E_ARTIFACT_REGISTRY_REPO }}
+      E2E_SERVICE_ACCOUNT: ${{ secrets.GCP_E2E_RUNTIME_SERVICE_ACCOUNT_EMAIL }}
+      E2E_CALLER_SERVICE_ACCOUNT: ${{ secrets.GCP_E2E_CLOUD_BUILD_SERVICE_ACCOUNT_EMAIL }}
+      TRACE_PUBSUB_TOPIC: ${{ secrets.GCP_E2E_TRACE_PUBSUB_TOPIC }}
+      TRACE_PUBSUB_SUBSCRIPTION: ${{ secrets.GCP_E2E_TRACE_PUBSUB_SUBSCRIPTION }}
+      RUN_REGION: ${{ secrets.GCP_E2E_RUN_REGION }}
 
     steps:
       - name: Checkout Code
@@ -31,8 +36,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
-          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          workload_identity_provider: ${{ secrets.GCP_WEEKLY_E2E_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WEEKLY_E2E_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
@@ -52,6 +57,11 @@ jobs:
           LIB_RUN_ID: ${{ github.run_id }}
           GCP_PROJECT_ID: ${{ env.GCP_PROJECT_ID }}
           GITHUB_TOKEN_SECRET_VERSION: ${{ env.GITHUB_TOKEN_SECRET_VERSION }}
+          ARTIFACT_REGISTRY_REPO: ${{ env.ARTIFACT_REGISTRY_REPO }}
+          E2E_SERVICE_ACCOUNT: ${{ env.E2E_SERVICE_ACCOUNT }}
+          E2E_CALLER_SERVICE_ACCOUNT: ${{ env.E2E_CALLER_SERVICE_ACCOUNT }}
+          TRACE_PUBSUB_TOPIC: ${{ env.TRACE_PUBSUB_TOPIC }}
+          TRACE_PUBSUB_SUBSCRIPTION: ${{ env.TRACE_PUBSUB_SUBSCRIPTION }}
           RUN_REGION: ${{ env.RUN_REGION }}
           GCS_BUCKET_NAME: ${{ env.GCS_BUCKET_NAME }}
           GCS_SOURCE_STAGING_DIR: ${{ env.GCS_SOURCE_STAGING_DIR }}

--- a/.github/workflows/weekly-latest-deps-e2e.yml
+++ b/.github/workflows/weekly-latest-deps-e2e.yml
@@ -74,9 +74,7 @@ jobs:
             echo "## Weekly Latest Dependency E2E"
             echo
             echo "- Status: ${{ steps.cloud_build.outputs.build_status }}"
-            echo "- Build ID: ${{ steps.cloud_build.outputs.build_id }}"
-            echo "- Logs: ${{ steps.cloud_build.outputs.build_log_url }}"
-            echo "- Artifacts: ${{ steps.cloud_build.outputs.artifacts_url }}"
+            echo "- Internal Cloud Build logs and artifacts are available to maintainers in Google Cloud."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail workflow when E2E failed

--- a/renovate.json
+++ b/renovate.json
@@ -90,6 +90,7 @@
       "dependencyDashboardApproval": false,
       "automerge": true,
       "automergeType": "pr",
+      "automergeStrategy": "squash",
       "labels": ["security", "security:floor", "renovate:type-security-floor"]
     },
     {


### PR DESCRIPTION
## Summary
- moves public GCP E2E workflow configuration to repo secrets and per-pipeline WIF identities
- adds signed release automation using the release bot SSH signing key
- removes hard-coded local GCP setup defaults from the public E2E setup surface
- makes Renovate security-floor automerge explicitly use squash to match repo rules

## Validation
- actionlint for changed workflows
- YAML parse for workflow files
- git diff --check
- conservative scan for committed GCP infrastructure identifiers
- full scripts/run_tests.py completed successfully before commit